### PR TITLE
feat: Makefileのgit-hooksターゲットを包括的プリコミットフック対応に更新

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,101 @@
+#!/bin/sh
+# 品質チェックとブランチルールを強制
+
+set -e
+
+echo "🪝 Pre-commit フック実行中..."
+
+# 現在のブランチ名を取得
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+# mainブランチへの直接コミット禁止
+if [ "$current_branch" = "main" ]; then
+    echo "❌ エラー: mainブランチへの直接コミットは禁止されています"
+    echo "   機能ブランチを作成してください:"
+    echo "   git checkout -b feat/your-feature-name"
+    exit 1
+fi
+
+# ブランチ命名規則チェック（mainブランチ以外）
+if [ "$current_branch" != "main" ]; then
+    valid_patterns="^(feat|fix|hotfix|test|docs|ci|cicd|refactor|perf|security|deps)/"
+    if ! echo "$current_branch" | grep -qE "$valid_patterns"; then
+        echo "❌ エラー: ブランチ名が命名規則に従っていません: $current_branch"
+        echo "   正しい形式:"
+        echo "   - feat/issue-X-feature-name     (新機能)"
+        echo "   - fix/issue-X-description       (バグ修正)"
+        echo "   - hotfix/X-description          (緊急修正)"
+        echo "   - test/X-description            (テスト)"
+        echo "   - docs/X-description            (ドキュメント)"
+        echo "   - ci/X-description              (CI/CD)"
+        echo "   - refactor/X-description        (リファクタリング)"
+        echo "   - perf/X-description           (性能改善)"
+        echo "   - security/X-description        (セキュリティ)"
+        echo "   - deps/X-description           (依存関係)"
+        exit 1
+    fi
+    
+    # Issue参照推奨（機能ブランチの場合）
+    if echo "$current_branch" | grep -qE "^(feat|fix|hotfix)/" && ! echo "$current_branch" | grep -qE "issue-[0-9]+"; then
+        echo "ℹ️  情報: ブランチ名にissue番号の含有を推奨します"
+        echo "   推奨形式: feat/issue-123-feature-name"
+    fi
+fi
+
+# 空のコミットメッセージチェック
+if [ -z "$(git diff --cached --name-only)" ]; then
+    echo "❌ エラー: ステージされた変更がありません"
+    exit 1
+fi
+
+# Go ファイルの変更がある場合の品質チェック
+go_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+if [ -n "$go_files" ]; then
+    echo "🔍 Go ファイルの品質チェック実行中..."
+    
+    # フォーマットチェック
+    echo "  ✨ フォーマットチェック..."
+    unformatted=$(echo "$go_files" | xargs gofmt -l)
+    if [ -n "$unformatted" ]; then
+        echo "❌ エラー: 以下のファイルがフォーマットされていません:"
+        echo "$unformatted"
+        echo "   修正するには: make fmt"
+        exit 1
+    fi
+    
+    
+    # 可能であればlintチェック
+    if command -v golangci-lint >/dev/null 2>&1; then
+        echo "  🔍 Lint チェック..."
+        if ! golangci-lint run --new-from-rev=HEAD~1; then
+            echo "❌ エラー: Lint チェックに失敗しました"
+            echo "   修正するには: make lint"
+            exit 1
+        fi
+    else
+        echo "  ⚠️  golangci-lint がインストールされていません（スキップ）"
+    fi
+    
+    # テスト実行（変更されたパッケージのみ）
+    echo "  🧪 テスト実行..."
+    packages=$(echo "$go_files" | xargs -I {} dirname {} | sort -u | xargs -I {} echo "./{}...")
+    if [ -n "$packages" ]; then
+        if ! go test $packages; then
+            echo "❌ エラー: テストに失敗しました"
+            exit 1
+        fi
+    fi
+fi
+
+# Makefileの変更がある場合
+makefile_changed=$(git diff --cached --name-only | grep -E '^Makefile$' || true)
+if [ -n "$makefile_changed" ]; then
+    echo "🔧 Makefile構文チェック..."
+    if ! make -n help >/dev/null 2>&1; then
+        echo "❌ エラー: Makefile構文エラーがあります"
+        exit 1
+    fi
+fi
+
+
+echo "✅ Pre-commit チェック完了"

--- a/Makefile
+++ b/Makefile
@@ -129,13 +129,19 @@ watch:
 
 # Git hooks
 .PHONY: git-hooks
-## git-hooks: Setup git pre-commit hooks
+## git-hooks: Setup git pre-commit hooks from .git-hooks folder
 git-hooks:
 	@echo "🔗 Git pre-commit hookを設定中..."
 	@mkdir -p .git/hooks
-	@echo '#!/bin/sh\nmake quality' > .git/hooks/pre-commit
-	@chmod +x .git/hooks/pre-commit
-	@echo "✅ Pre-commit hook設定完了"
+	@if [ -f .git-hooks/pre-commit ]; then \
+		cp .git-hooks/pre-commit .git/hooks/pre-commit; \
+		chmod +x .git/hooks/pre-commit; \
+		echo "✅ Pre-commit hook設定完了 (.git-hooks/pre-commit から)"; \
+	else \
+		echo '#!/bin/sh\nmake quality' > .git/hooks/pre-commit; \
+		chmod +x .git/hooks/pre-commit; \
+		echo "✅ Pre-commit hook設定完了 (フォールバック)"; \
+	fi
 
 # Release helpers
 .PHONY: release-dry-run release-patch release-minor release-major


### PR DESCRIPTION
## 概要
Makefileの`git-hooks`ターゲットを更新し、`.git-hooks`フォルダから包括的なpre-commitフックをインストールできるようになりました。

## 変更内容

### 🔧 Makefile更新
- `.git-hooks/pre-commit`から包括的なフックをコピー
- フォールバック機能: `.git-hooks`が存在しない場合は従来の簡易版を使用
- より詳細な成功メッセージで実際に使用されたフックを表示

### 🪝 Pre-commitフック機能
既存の`.git-hooks/pre-commit`は以下の機能を提供:

**ブランチ保護:**
- mainブランチへの直接コミット禁止
- ブランチ命名規則チェック (`feat/`, `fix/`, `hotfix/`, `test/`, `docs/`, `ci/`, `refactor/`, `perf/`, `security/`, `deps/`)
- Issue番号含有の推奨 (`feat/issue-123-feature-name`)

**品質チェック:**
- Goファイルのフォーマットチェック (`gofmt`)
- Lint チェック (`golangci-lint` - 利用可能な場合)
- テスト実行 (変更されたパッケージのみ)
- Makefile構文チェック

## テスト

### 動作確認
```bash
# フック インストール
make git-hooks

# mainブランチでのコミット禁止テスト
git checkout main
echo "test" > test.txt && git add test.txt
git commit -m "test"  # ❌ エラー: mainブランチへの直接コミット禁止

# 機能ブランチでの正常動作
git checkout -b feat/test-feature
git commit -m "test"  # ✅ 成功
```

### Pre-commitフック実行例
```
🪝 Pre-commit フック実行中...
ℹ️  情報: ブランチ名にissue番号の含有を推奨します
   推奨形式: feat/issue-123-feature-name
🔧 Makefile構文チェック...
✅ Pre-commit チェック完了
```

## 使用方法

```bash
# Git hooksをインストール
make git-hooks

# 以降、全てのコミットで自動的にチェック実行
git commit -m "your commit message"
```

## セキュリティと品質向上

- **開発ワークフロー強制**: CLAUDE.mdで定義されたGitワークフローの自動強制
- **コード品質保証**: 自動的なフォーマット・lint・テストチェック
- **ブランチ戦略遵守**: 命名規則とmainブランチ保護の自動化
- **早期エラー検出**: コミット前の包括的チェックで問題の早期発見

🤖 Generated with [Claude Code](https://claude.ai/code)