### PR TITLE
ci: Makefile品質チェックからgo vetを削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Beaver - AIエージェント知識ダム構築ツール
 # Makefile for development and build automation
 
-.PHONY: help build clean test lint fmt vet deps install run dev quality
+.PHONY: help build clean test lint fmt deps install run dev quality
 
 # Variables
 BINARY_NAME=beaver
@@ -72,17 +72,13 @@ fmt:
 	@echo "📝 コードをフォーマット中..."
 	go fmt ./...
 
-## vet: Run go vet
-vet:
-	@echo "🔍 go vetを実行中..."
-	go vet ./...
 
-## quality: Run all quality checks (lint + format + vet + test)
-quality: fmt vet lint test
+## quality: Run all quality checks (lint + format + test)
+quality: fmt lint test
 	@echo "✅ 品質チェック完了"
 
 ## quality-fix: Auto-fix issues where possible
-quality-fix: fmt vet
+quality-fix: fmt
 	@echo "🔧 自動修正を実行中..."
 	@if command -v golangci-lint >/dev/null 2>&1; then \
 		golangci-lint run --fix; \


### PR DESCRIPTION
## 概要
Makefileの品質チェックターゲットから古い`go vet`を削除しました。

## 変更内容
- **quality target**: `fmt + vet + lint + test` → `fmt + lint + test`
- **quality-fix target**: `fmt + vet + auto-fix` → `fmt + auto-fix`
- **vet target**: 完全に削除
- **.PHONY**: `vet`を削除

## 理由
- `go vet`は古いツールで、現代的な`golangci-lint`に機能が統合済み
- 重複したチェックを避け、ビルドパイプラインを効率化
- `golangci-lint`の方が高機能で設定可能

## テスト
- ✅ `make quality`: 正常動作確認
- ✅ `make quality-fix`: 正常動作確認  
- ✅ Pre-commitフック: Makefile構文チェック通過

🤖 Generated with [Claude Code](https://claude.ai/code)