### PR TITLE
fix: update GitHub Actions to use correct repository secrets/variables

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -100,9 +100,9 @@ jobs:
     - name: Run integration tests
       env:
         BEAVER_INTEGRATION_TESTS: true
-        GITHUB_TOKEN: ${{ secrets.INTEGRATION_GITHUB_TOKEN }}
-        BEAVER_TEST_REPO_OWNER: ${{ secrets.BEAVER_TEST_REPO_OWNER }}
-        BEAVER_TEST_REPO_NAME: ${{ secrets.BEAVER_TEST_REPO_NAME }}
+        GITHUB_TOKEN: ${{ secrets.BEAVER_GITHUB_TOKEN }}
+        BEAVER_TEST_REPO_OWNER: ${{ vars.BEAVER_TEST_REPO_OWNER }}
+        BEAVER_TEST_REPO_NAME: ${{ vars.BEAVER_TEST_REPO_NAME }}
         BEAVER_DEBUG: true
       run: |
         echo "🧪 Running integration tests..."
@@ -173,9 +173,9 @@ jobs:
     - name: Run performance integration tests
       env:
         BEAVER_INTEGRATION_TESTS: true
-        GITHUB_TOKEN: ${{ secrets.INTEGRATION_GITHUB_TOKEN }}
-        BEAVER_TEST_REPO_OWNER: ${{ secrets.BEAVER_TEST_REPO_OWNER }}
-        BEAVER_TEST_REPO_NAME: ${{ secrets.BEAVER_TEST_REPO_NAME }}
+        GITHUB_TOKEN: ${{ secrets.BEAVER_GITHUB_TOKEN }}
+        BEAVER_TEST_REPO_OWNER: ${{ vars.BEAVER_TEST_REPO_OWNER }}
+        BEAVER_TEST_REPO_NAME: ${{ vars.BEAVER_TEST_REPO_NAME }}
       run: |
         echo "🚀 Running performance tests..."
         ./scripts/run-integration-tests.sh --all --run


### PR DESCRIPTION
## 概要
GitHub Actions integration testsの環境変数設定を修正

## 問題
Integration testsが以下のエラーで失敗していました：
```
GITHUB_TOKEN not set. Please set your GitHub Personal Access Token.
BEAVER_TEST_REPO_OWNER not set. Please set your GitHub username.
BEAVER_TEST_REPO_NAME not set. Please set your test repository name.
```

## 原因
Workflow fileの環境変数名がrepository設定と一致していませんでした：

**Before (incorrect):**
- `secrets.INTEGRATION_GITHUB_TOKEN` 
- `secrets.BEAVER_TEST_REPO_OWNER`
- `secrets.BEAVER_TEST_REPO_NAME`

**After (correct):**
- `secrets.BEAVER_GITHUB_TOKEN` (repository secret)
- `vars.BEAVER_TEST_REPO_OWNER` (repository variable) 
- `vars.BEAVER_TEST_REPO_NAME` (repository variable)

## 変更内容
- Integration Tests stepの環境変数を修正
- Performance Tests stepの環境変数を修正
- Repository secretsとvariablesの正しい参照方法に更新

## テスト
- ✅ Pre-commit hooks passed
- ✅ Repository configuration alignment verified

これでユーザーが設定したrepository secrets/variablesが正しく使用されます。

🤖 Generated with [Claude Code](https://claude.ai/code)