### PR TITLE
fix: CI/CDワークフローのGitHub-hostedランナー復帰

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   # Fast checks that run on every push/PR
   quality-checks:
     name: 🔍 Quality & Security
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       coverage-file: ${{ steps.coverage.outputs.file }}
     
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
-        cache: false
+        cache: true
 
     - name: 📦 Download dependencies
       run: go mod download
@@ -69,7 +69,7 @@ jobs:
   # Build verification (runs in parallel with quality-checks)
   build-test:
     name: 🔨 Build Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     
     steps:
     - name: 📥 Checkout code
@@ -79,7 +79,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
-        cache: false
+        cache: true
 
     - name: 📦 Download dependencies
       run: go mod download
@@ -101,7 +101,7 @@ jobs:
   # Integration tests (conditional)
   integration-tests:
     name: 🔗 Integration Tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [quality-checks, build-test]
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -118,7 +118,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
-        cache: false
+        cache: true
         
     - name: 📦 Download dependencies
       run: go mod download
@@ -156,7 +156,7 @@ jobs:
   # Performance tests (main branch only)
   performance-tests:
     name: 🚀 Performance Tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [quality-checks, build-test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     
@@ -170,7 +170,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
-        cache: false
+        cache: true
         
     - name: 📦 Download dependencies
       run: go mod download
@@ -200,7 +200,7 @@ jobs:
   # Final status
   ci-complete:
     name: ✅ CI Complete
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [quality-checks, build-test, integration-tests, performance-tests]
     if: always()
     


### PR DESCRIPTION
## 概要
self-hosted環境でのGit認証問題を修正するため、GitHub-hostedランナーに復帰

## 変更内容
- 全ジョブを `runs-on: ubuntu-latest` に変更
- `cache: true` に復帰（GitHub-hosted環境では効率的）
- self-hosted環境でのGit認証エラー回避

## 問題の詳細
self-hosted環境で以下のエラーが発生:
```
fatal: could not read Password for 'https://***@github.com': No such device or address
```

## テスト
- ConflictResolverと拡張ログ機能は正常動作確認済み
- GitHub-hosted環境での統合テスト実行で問題解決予想

Closes #100 (if exists)