### PR TITLE
fix: performance test content deduplication issue

### DIFF
--- a/tests/integration/wiki_integration_test.go
+++ b/tests/integration/wiki_integration_test.go
@@ -590,6 +590,9 @@ This content mixes Japanese and English to ensure proper handling of multilingua
 
 func generateLargeContentPages(count int) []*wiki.WikiPage {
 	var pages []*wiki.WikiPage
+	
+	// Add timestamp to ensure unique content each run
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
 
 	for i := 1; i <= count; i++ {
 		content := fmt.Sprintf(`# Large Content Page %d
@@ -597,8 +600,9 @@ func generateLargeContentPages(count int) []*wiki.WikiPage {
 ## Overview
 
 This is a large content page generated for performance testing.
+**Generated at:** %s
 
-`, i)
+`, i, timestamp)
 
 		// Add substantial content
 		for j := 1; j <= 50; j++ {
@@ -624,11 +628,11 @@ architecto beatae vitae dicta sunt explicabo.
 `, j, i, j, i, j, i)
 		}
 
-		content += `
+		content += fmt.Sprintf(`
 
 ---
-*Generated with Beaver for performance testing*
-`
+*Generated with Beaver for performance testing at %s*
+`, timestamp)
 
 		pages = append(pages, &wiki.WikiPage{
 			Title:    fmt.Sprintf("Large Content Page %d", i),


### PR DESCRIPTION
## 概要
GitHub Wikiのコンテンツ重複排除によるパフォーマンステスト失敗を修正

## 問題の詳細
パフォーマンステストが以下のエラーで失敗:
```
ERROR Git commit failed: exit status 1, output: 
nothing to commit, working tree clean
```

**根本原因**: GitHub Wikiが同一コンテンツを重複排除するため、CI実行時に同じ422KBのコンテンツを繰り返し生成すると「コミットするものがない」エラーが発生

## 変更内容
- `generateLargeContentPages()`にタイムスタンプを追加
- 各テスト実行で一意のコンテンツを生成
- GitHub Wikiの重複排除を回避

## テスト
- 全ての品質チェックが通過 ✅
- 0セキュリティ問題検出 ✅
- 全単体テスト通過 ✅

## 期待される結果
- パフォーマンステストが正常完了
- ConflictResolverと拡張ログ機能の安定動作
- CI/CDパイプライン完全成功

Closes #102 (if exists)