### PR TITLE
fix: GitHub Actions Wiki自動化環境設定の無効化

### DIFF
--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -86,8 +86,8 @@ jobs:
     needs: pre-checks
     if: needs.pre-checks.outputs.should_update == 'true'
     
-    # Use environment for sensitive operations
-    environment: wiki-automation
+    # Use environment for sensitive operations (configure 'wiki-automation' environment in repository settings)
+    # environment: wiki-automation
     
     steps:
     - name: 📥 Checkout code


### PR DESCRIPTION
## 概要
Wiki自動化ワークフローでの診断エラー修正 - 環境設定が未構成の場合の対応

## 変更内容
- `wiki-automation` environment設定をコメントアウト
- リポジトリ設定でenvironmentを作成するまで無効化
- 設定手順をコメントで明記

## 修正内容
```yaml
# Use environment for sensitive operations (configure 'wiki-automation' environment in repository settings)
# environment: wiki-automation
```

## 背景
- PR #108 マージ後にIDEで診断エラーが発生
- GitHub repository settingsでenvironmentが未作成のため
- 手動設定まで一時的に無効化

## テスト
- ✅ YAML構文エラー解消確認
- ✅ 品質チェック全合格

Closes #diagnostic-environment-error