### PR TITLE
fix: GitHub Actions Wiki workflow permissions and CLI issues

### DIFF
--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -1,5 +1,11 @@
 name: 📖 Wiki Auto-Update
 
+# Required permissions for GitHub Actions
+permissions:
+  contents: read        # Read repository contents
+  issues: write        # Create issues on failure
+  actions: read        # Read workflow information
+
 on:
   # Issues closed - triggers wiki update
   issues:
@@ -113,8 +119,11 @@ jobs:
         
     - name: ✅ Verify build
       run: |
-        ./bin/beaver --version
+        # Verify beaver binary is executable and shows help
         ./bin/beaver --help
+        
+        # Verify beaver can show available commands
+        ./bin/beaver help
         
     - name: ⚙️ Setup Beaver configuration
       env:


### PR DESCRIPTION
## 概要
Wiki自動化ワークフローの権限とCLI検証エラーの修正

## 変更内容
- **権限設定追加**: GitHub Actionsに必要な権限を明示的に設定
  -  - リポジトリ内容の読み取り
  -  - 失敗時のIssue作成
  -  - ワークフロー情報の読み取り
- **CLI検証修正**: 未対応のフラグを削除
- **検証方法更新**: サポートされているとコマンドを使用

## 修正内容
- ワークフロー実行時の403エラー（権限不足）を解決
- beaver CLI のフラグエラーを解決
- より信頼性の高い検証プロセスを実装

## テスト
- ✅ 全品質チェック合格
- ✅ ローカルでの beaver CLI 動作確認
- ✅ ワークフロー構文チェック

## 背景
main ブランチでのWiki自動化ワークフローが失敗していた問題:
1. GitHub Actions トークンの権限不足でIssue作成に失敗
2. beaver CLI がフラグをサポートしていない

Closes #wiki-workflow-failure