### PR TITLE
fix: Wiki workflow beaver init unsupported flag

### DIFF
--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -133,7 +133,7 @@ jobs:
         # Create beaver.yml if it doesn't exist
         if [ ! -f "$BEAVER_CONFIG_FILE" ]; then
           echo "📝 Creating Beaver configuration..."
-          ./bin/beaver init --non-interactive
+          ./bin/beaver init
         fi
         
         # Update configuration for current repository


### PR DESCRIPTION
## 概要
Wiki Auto-Update workflow が `beaver init --non-interactive` の未対応フラグで失敗していた問題を修正

## 変更内容
- `.github/workflows/wiki-update.yml` の `beaver init` コマンドから `--non-interactive` フラグを削除
- beaver CLI は `--non-interactive` フラグをサポートしていないことを確認済み
- 標準の `beaver init` コマンドを使用するよう変更

## テスト
- CLI ヘルプ出力で利用可能なフラグを確認: `beaver init --help` では `-h, --help` のみサポート
- 修正後のワークフローは正常に動作することを期待

Closes #112

🤖 Generated with [Claude Code](https://claude.ai/code)