### PR TITLE
fix: GitHub Actions Wiki workflow beaver fetchコマンド構文修正

### DIFF
--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -178,11 +178,11 @@ jobs:
         echo "📊 Analyzing repository issues for wiki content..."
         
         # Get recent issues for wiki update
-        ./bin/beaver fetch ${{ github.repository }} \
+        ./bin/beaver fetch issues ${{ github.repository }} \
           --state=all \
           --sort=updated \
           --per-page=50 \
-          --output=json > issues.json
+          --output=issues.json
         
         issue_count=$(jq '.fetched_count' issues.json)
         echo "📋 Found $issue_count issues to process"


### PR DESCRIPTION
## 概要
GitHub Actions Wiki自動更新ワークフローでbeaver fetchコマンドが失敗していたため、正しいコマンド構文に修正。

## 変更内容
- `beaver fetch` → `beaver fetch issues` に修正
- beaver CLIの正しいサブコマンド構文を使用

## テスト
- ワークフローが正常実行されることを確認
- beaver fetch issuesコマンドのヘルプで構文確認済み

Closes #114