### PR TITLE
feat: Tokyo タイムゾーン設定とWiki生成時刻表示の改善

### DIFF
--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -17,7 +17,7 @@ on:
   
   # Weekly scheduled updates - sync any missed updates
   schedule:
-    - cron: '0 2 * * 0'  # Every Sunday at 2 AM UTC
+    - cron: '0 17 * * 6'  # Every Saturday at 5 PM UTC (2 AM JST Sunday)
   
   # Manual trigger for on-demand updates
   workflow_dispatch:
@@ -248,7 +248,7 @@ jobs:
         
         ## Last Updated
         
-        This wiki was last updated automatically on $(date -u '+%Y-%m-%d %H:%M:%S UTC').
+        This wiki was last updated automatically on $(TZ='Asia/Tokyo' date '+%Y-%m-%d %H:%M:%S JST').
         
         ---
         *This wiki is maintained automatically. For manual updates, please create issues or update the source documentation.*
@@ -283,7 +283,7 @@ jobs:
         cat > Home.md << EOF
         # ${{ github.repository }} Wiki
         
-        **Last Updated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')  
+        **Last Updated:** $(TZ='Asia/Tokyo' date '+%Y-%m-%d %H:%M:%S JST')  
         **Update Trigger:** ${{ github.event_name }}
         
         ## Project Overview
@@ -344,7 +344,7 @@ jobs:
         
         ## Statistics
         
-        **Last Updated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+        **Last Updated:** $(TZ='Asia/Tokyo' date '+%Y-%m-%d %H:%M:%S JST')
         
         EOF
           
@@ -402,7 +402,7 @@ jobs:
       run: |
         echo "📊 Wiki Update Summary:"
         echo "🎯 Trigger: ${{ github.event_name }}"
-        echo "⏰ Completed: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+        echo "⏰ Completed: $(TZ='Asia/Tokyo' date '+%Y-%m-%d %H:%M:%S JST')"
         echo "🔗 Repository: ${{ github.repository }}"
         
         if [ "${{ job.status }}" = "success" ]; then

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,16 +4,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/viper"
 )
 
 // Config represents the Beaver configuration structure
 type Config struct {
-	Project ProjectConfig `mapstructure:"project"`
-	Sources SourcesConfig `mapstructure:"sources"`
-	Output  OutputConfig  `mapstructure:"output"`
-	AI      AIConfig      `mapstructure:"ai"`
+	Project  ProjectConfig  `mapstructure:"project"`
+	Sources  SourcesConfig  `mapstructure:"sources"`
+	Output   OutputConfig   `mapstructure:"output"`
+	AI       AIConfig       `mapstructure:"ai"`
+	Timezone TimezoneConfig `mapstructure:"timezone"`
 }
 
 // ProjectConfig holds project-specific settings
@@ -58,6 +60,12 @@ type AIFeatures struct {
 	Summarization   bool `mapstructure:"summarization"`
 	Categorization  bool `mapstructure:"categorization"`
 	Troubleshooting bool `mapstructure:"troubleshooting"`
+}
+
+// TimezoneConfig holds timezone settings
+type TimezoneConfig struct {
+	Location string `mapstructure:"location"`
+	Format   string `mapstructure:"format"`
 }
 
 var globalConfig *Config
@@ -144,6 +152,10 @@ ai:
     summarization: true   # 要約
     categorization: true  # 分類
     troubleshooting: true # トラブルシューティング
+
+timezone:
+  location: "Asia/Tokyo"  # タイムゾーン設定 (JST)
+  format: "2006-01-02 15:04:05 JST"  # 時刻フォーマット
 `
 
 	configPath := "beaver.yml"
@@ -172,6 +184,8 @@ func setDefaults() {
 	viper.SetDefault("ai.features.summarization", true)
 	viper.SetDefault("ai.features.categorization", false)
 	viper.SetDefault("ai.features.troubleshooting", false)
+	viper.SetDefault("timezone.location", "Asia/Tokyo")
+	viper.SetDefault("timezone.format", "2006-01-02 15:04:05 JST")
 }
 
 // ValidateConfig validates the loaded configuration
@@ -202,6 +216,11 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("無効な AI provider: %s", c.AI.Provider)
 	}
 
+	// Validate timezone
+	if _, err := time.LoadLocation(c.Timezone.Location); err != nil {
+		return fmt.Errorf("無効なタイムゾーン: %s (%w)", c.Timezone.Location, err)
+	}
+
 	return nil
 }
 
@@ -217,4 +236,30 @@ func GetConfigPath() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("設定ファイルが見つかりません")
+}
+
+// GetTimezone returns the configured timezone location
+func (c *Config) GetTimezone() (*time.Location, error) {
+	return time.LoadLocation(c.Timezone.Location)
+}
+
+// FormatTime formats time according to the configured timezone and format
+func (c *Config) FormatTime(t time.Time) (string, error) {
+	location, err := c.GetTimezone()
+	if err != nil {
+		return "", err
+	}
+
+	localTime := t.In(location)
+	return localTime.Format(c.Timezone.Format), nil
+}
+
+// Now returns the current time in the configured timezone
+func (c *Config) Now() time.Time {
+	location, err := c.GetTimezone()
+	if err != nil {
+		// Fallback to UTC if timezone loading fails
+		return time.Now().UTC()
+	}
+	return time.Now().In(location)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -524,4 +525,133 @@ func containsAt(s, substr string, start int) bool {
 		}
 	}
 	return false
+}
+
+func TestTimezoneConfig(t *testing.T) {
+	t.Run("Valid timezone configuration", func(t *testing.T) {
+		config := Config{
+			Project: ProjectConfig{
+				Repository: "owner/repo",
+			},
+			Sources: SourcesConfig{
+				GitHub: GitHubConfig{
+					Token: "test-token",
+				},
+			},
+			Output: OutputConfig{
+				Wiki: WikiConfig{
+					Platform: "github",
+				},
+			},
+			AI: AIConfig{
+				Provider: "openai",
+			},
+			Timezone: TimezoneConfig{
+				Location: "Asia/Tokyo",
+				Format:   "2006-01-02 15:04:05 JST",
+			},
+		}
+
+		err := config.Validate()
+		if err != nil {
+			t.Errorf("Validate() with valid timezone error = %v", err)
+		}
+
+		// Test GetTimezone
+		location, err := config.GetTimezone()
+		if err != nil {
+			t.Errorf("GetTimezone() error = %v", err)
+			return
+		}
+
+		if location.String() != "Asia/Tokyo" {
+			t.Errorf("Expected timezone 'Asia/Tokyo', got %s", location.String())
+		}
+	})
+
+	t.Run("Invalid timezone configuration", func(t *testing.T) {
+		config := Config{
+			Project: ProjectConfig{
+				Repository: "owner/repo",
+			},
+			Sources: SourcesConfig{
+				GitHub: GitHubConfig{
+					Token: "test-token",
+				},
+			},
+			Output: OutputConfig{
+				Wiki: WikiConfig{
+					Platform: "github",
+				},
+			},
+			AI: AIConfig{
+				Provider: "openai",
+			},
+			Timezone: TimezoneConfig{
+				Location: "Invalid/Timezone",
+				Format:   "2006-01-02 15:04:05 JST",
+			},
+		}
+
+		err := config.Validate()
+		if err == nil {
+			t.Error("Validate() should return error for invalid timezone")
+		}
+	})
+
+	t.Run("FormatTime with Tokyo timezone", func(t *testing.T) {
+		config := Config{
+			Timezone: TimezoneConfig{
+				Location: "Asia/Tokyo",
+				Format:   "2006-01-02 15:04:05 JST",
+			},
+		}
+
+		// Use a fixed time for consistent testing
+		testTime := time.Date(2024, 6, 28, 12, 0, 0, 0, time.UTC)
+		formatted, err := config.FormatTime(testTime)
+		if err != nil {
+			t.Errorf("FormatTime() error = %v", err)
+			return
+		}
+
+		// In JST, UTC 12:00 becomes 21:00
+		expected := "2024-06-28 21:00:00 JST"
+		if formatted != expected {
+			t.Errorf("FormatTime() expected '%s', got '%s'", expected, formatted)
+		}
+	})
+
+	t.Run("Now returns time in configured timezone", func(t *testing.T) {
+		config := Config{
+			Timezone: TimezoneConfig{
+				Location: "Asia/Tokyo",
+				Format:   "2006-01-02 15:04:05 JST",
+			},
+		}
+
+		now := config.Now()
+		location := now.Location()
+
+		if location.String() != "Asia/Tokyo" {
+			t.Errorf("Now() should return time in Asia/Tokyo timezone, got %s", location.String())
+		}
+	})
+
+	t.Run("Default timezone values", func(t *testing.T) {
+		// Clear viper to get defaults
+		viper.Reset()
+		setDefaults()
+
+		location := viper.GetString("timezone.location")
+		format := viper.GetString("timezone.format")
+
+		if location != "Asia/Tokyo" {
+			t.Errorf("Default timezone location should be 'Asia/Tokyo', got %s", location)
+		}
+
+		if format != "2006-01-02 15:04:05 JST" {
+			t.Errorf("Default timezone format should be '2006-01-02 15:04:05 JST', got %s", format)
+		}
+	})
 }

--- a/pkg/wiki/generator.go
+++ b/pkg/wiki/generator.go
@@ -5,19 +5,27 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nyasuto/beaver/internal/config"
 	"github.com/nyasuto/beaver/internal/models"
 )
 
 // Generator generates Wiki content from GitHub Issues
 type Generator struct {
 	templateManager *TemplateManager
+	config          *config.Config
 }
 
 // NewGenerator creates a new Wiki generator
 func NewGenerator() *Generator {
 	return &Generator{
 		templateManager: NewTemplateManager(),
+		config:          config.GetConfig(),
 	}
+}
+
+// now returns the current time in the configured timezone
+func (g *Generator) now() time.Time {
+	return g.config.Now()
 }
 
 // WikiPage represents a generated Wiki page
@@ -117,7 +125,7 @@ type IndexData struct {
 func (g *Generator) GenerateIssuesSummary(issues []models.Issue, projectName string) (*WikiPage, error) {
 	data := IssuesSummaryData{
 		ProjectName:   projectName,
-		GeneratedAt:   time.Now(),
+		GeneratedAt:   g.now(),
 		TotalIssues:   len(issues),
 		Issues:        issues,
 		AIProcessor:   "OpenAI/Anthropic",
@@ -142,8 +150,8 @@ func (g *Generator) GenerateIssuesSummary(issues []models.Issue, projectName str
 		Title:     fmt.Sprintf("%s - Issues Summary", projectName),
 		Content:   content,
 		Filename:  "Issues-Summary.md",
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: g.now(),
+		UpdatedAt: g.now(),
 		Summary:   fmt.Sprintf("Summary of %d GitHub Issues processed by Beaver AI", len(issues)),
 		Category:  "Summary",
 		Tags:      []string{"issues", "summary", "ai-processed"},
@@ -162,7 +170,7 @@ func (g *Generator) GenerateTroubleshootingGuide(issues []models.Issue, projectN
 
 	data := TroubleshootingData{
 		ProjectName:  projectName,
-		GeneratedAt:  time.Now(),
+		GeneratedAt:  g.now(),
 		SolvedIssues: solvedIssues,
 		CommonErrors: g.extractErrorPatterns(solvedIssues),
 		Solutions:    g.extractSolutions(solvedIssues),
@@ -177,8 +185,8 @@ func (g *Generator) GenerateTroubleshootingGuide(issues []models.Issue, projectN
 		Title:     fmt.Sprintf("%s - Troubleshooting Guide", projectName),
 		Content:   content,
 		Filename:  "Troubleshooting-Guide.md",
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: g.now(),
+		UpdatedAt: g.now(),
 		Summary:   fmt.Sprintf("Troubleshooting guide based on %d solved issues", len(solvedIssues)),
 		Category:  "Guide",
 		Tags:      []string{"troubleshooting", "solutions", "closed-issues"},
@@ -189,7 +197,7 @@ func (g *Generator) GenerateTroubleshootingGuide(issues []models.Issue, projectN
 func (g *Generator) GenerateLearningPath(issues []models.Issue, projectName string) (*WikiPage, error) {
 	data := LearningPathData{
 		ProjectName:   projectName,
-		GeneratedAt:   time.Now(),
+		GeneratedAt:   g.now(),
 		Milestones:    g.extractMilestones(issues),
 		Technologies:  g.extractTechnologies(issues),
 		LearningGoals: g.extractLearningGoals(issues),
@@ -204,8 +212,8 @@ func (g *Generator) GenerateLearningPath(issues []models.Issue, projectName stri
 		Title:     fmt.Sprintf("%s - Learning Path", projectName),
 		Content:   content,
 		Filename:  "Learning-Path.md",
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: g.now(),
+		UpdatedAt: g.now(),
 		Summary:   "Development learning path extracted from project evolution",
 		Category:  "Learning",
 		Tags:      []string{"learning", "milestones", "technologies"},
@@ -485,10 +493,10 @@ func (g *Generator) GenerateAllPages(issues []models.Issue, projectName string) 
 func (g *Generator) GenerateIndex(issues []models.Issue, projectName string) (*WikiPage, error) {
 	data := IndexData{
 		ProjectName: projectName,
-		GeneratedAt: time.Now(),
+		GeneratedAt: g.now(),
 		TotalIssues: len(issues),
 		Status:      "Active",
-		LastUpdate:  time.Now(),
+		LastUpdate:  g.now(),
 	}
 
 	content, err := g.renderTemplate("index", data)
@@ -500,8 +508,8 @@ func (g *Generator) GenerateIndex(issues []models.Issue, projectName string) (*W
 		Title:     fmt.Sprintf("%s - Home", projectName),
 		Content:   content,
 		Filename:  "Home.md",
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: g.now(),
+		UpdatedAt: g.now(),
 		Summary:   fmt.Sprintf("Main index page for %s knowledge base", projectName),
 		Category:  "Index",
 		Tags:      []string{"index", "home", "navigation"},


### PR DESCRIPTION
## 概要

GMT/UTC時刻表示を日本時間(JST/Asia/Tokyo)に変更し、日本のユーザーにとって分かりやすいタイムスタンプ表示を実現します。

## 主要な変更内容

### 🕐 タイムゾーン設定システム
- **新機能**: `TimezoneConfig`構造体を追加してタイムゾーン設定を管理
- **デフォルト**: Asia/Tokyoをデフォルトタイムゾーンに設定
- **検証**: タイムゾーン設定の妥当性検証機能を追加
- **ユーティリティ**: `GetTimezone()`, `FormatTime()`, `Now()`メソッドを提供

### 📝 Wiki生成の改善
- **変更前**: `2025-06-28 13:01:27 UTC` (GMT表示)
- **変更後**: `2025-06-28 22:01:27 JST` (東京時間表示)
- 全てのWikiページタイムスタンプをJST表示に統一
- `time.Now()`から設定可能なタイムゾーン対応に移行

### ⚙️ GitHub Actions Workflow更新
- ワークフロー内の全ての日時表示をJSTに変更
- `$(date -u '+%Y-%m-%d %H:%M:%S UTC')` → `$(TZ='Asia/Tokyo' date '+%Y-%m-%d %H:%M:%S JST')`
- 週次実行スケジュールを日本時間基準に調整 (土曜17:00 UTC = 日曜2:00 JST)

### 🧪 テストカバレッジ拡充
- タイムゾーン設定の包括的テストを追加
- 無効なタイムゾーン設定の検証テスト
- フォーマット機能とデフォルト値のテスト
- 全てのテストが正常に実行されることを確認 ✅

## ユーザー体験向上

### Before (GMT/UTC)
```
**Last Updated:** 2025-06-28 13:01:27 UTC
**Generated:** 2025-06-28 13:01:27 UTC
```

### After (JST)
```
**Last Updated:** 2025-06-28 22:01:27 JST
**Generated:** 2025-06-28 22:01:27 JST
```

## 技術的改善点

- **設定可能**: 他のタイムゾーンにも対応可能な設計
- **後方互換性**: 既存の設定ファイルとの互換性を維持
- **拡張性**: 将来的な国際化対応に配慮した実装
- **品質保証**: 十分なテストカバレッジで品質を担保

## テスト

- [ ] ローカルでのタイムゾーン設定テスト
- [ ] Wiki生成でのJST表示確認
- [ ] GitHub Actions Workflowでの時刻表示確認
- [ ] 設定ファイルのデフォルト値確認
- [ ] 無効なタイムゾーン設定時のエラーハンドリング確認

🤖 Generated with [Claude Code](https://claude.ai/code)