### PR TITLE
refactor: Notion/Confluence対応オプションを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,13 @@ graph LR
     D --> E[AI処理エンジン]
     E --> F[Wiki生成器]
     F --> G[GitHub Wiki]
-    F --> H[Notion/Confluence]
 ```
 
 **技術スタック:**
 - **バックエンド**: Go（GitHub API、高性能、既存経験）
 - **AI処理**: Python（LangChain、OpenAI SDK、豊富なMLエコシステム）
 - **連携**: GoとPythonサービス間のREST API通信
-- **ストレージ**: GitHub Wiki、Notion、Confluence（設定可能）
+- **ストレージ**: GitHub Wiki
 
 **GitHub Wiki更新方式:**
 - **Git Clone方式**: `git clone https://github.com/owner/repo.wiki.git`
@@ -140,7 +139,7 @@ beaver summarize # AI要約機能
 - [ ] 複数リポジトリサポート
 - [ ] チーム学習分析
 - [ ] 知識ギャップ特定
-- [ ] 外部ツール統合（Notion、Confluence）
+- [ ] 外部プラットフォーム統合
 - [ ] 知識探索用Webダッシュボード
 
 **高度なAI:**
@@ -402,7 +401,7 @@ sources:
   
 output:
   wiki:
-    platform: "github"    # github, notion, confluence
+    platform: "github"    # github
     templates: "default"  # default, academic, startup
     
 ai:

--- a/beaver.yml.example
+++ b/beaver.yml.example
@@ -11,8 +11,8 @@ sources:
 
 output:
   wiki:
-    platform: "github"    # github, notion, confluence
-    templates: "default"  # default, academic, startup
+    platform: "github"
+    templates: "default"
 
 ai:
   provider: "openai"      # openai, anthropic, local

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,8 +147,8 @@ sources:
 
 output:
   wiki:
-    platform: "github"    # github, notion, confluence
-    templates: "default"  # default, academic, startup
+    platform: "github"
+    templates: "default"
 
 ai:
   provider: "openai"      # openai, anthropic, local
@@ -204,9 +204,7 @@ func (c *Config) Validate() error {
 	}
 
 	validPlatforms := map[string]bool{
-		"github":     true,
-		"notion":     true,
-		"confluence": true,
+		"github": true,
 	}
 	if !validPlatforms[c.Output.Wiki.Platform] {
 		return fmt.Errorf("無効な wiki platform: %s", c.Output.Wiki.Platform)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,50 +122,6 @@ func TestConfig_Validate(t *testing.T) {
 			wantError: true,
 			errorMsg:  "無効な AI provider: invalid",
 		},
-		{
-			name: "Valid notion platform",
-			config: Config{
-				Project: ProjectConfig{
-					Repository: "owner/repo",
-				},
-				Sources: SourcesConfig{
-					GitHub: GitHubConfig{
-						Token: "test-token",
-					},
-				},
-				Output: OutputConfig{
-					Wiki: WikiConfig{
-						Platform: "notion",
-					},
-				},
-				AI: AIConfig{
-					Provider: "anthropic",
-				},
-			},
-			wantError: false,
-		},
-		{
-			name: "Valid confluence platform",
-			config: Config{
-				Project: ProjectConfig{
-					Repository: "owner/repo",
-				},
-				Sources: SourcesConfig{
-					GitHub: GitHubConfig{
-						Token: "test-token",
-					},
-				},
-				Output: OutputConfig{
-					Wiki: WikiConfig{
-						Platform: "confluence",
-					},
-				},
-				AI: AIConfig{
-					Provider: "local",
-				},
-			},
-			wantError: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -355,7 +311,7 @@ sources:
 
 output:
   wiki:
-    platform: "notion"
+    platform: "github"
     templates: "academic"
 
 ai:
@@ -391,8 +347,8 @@ ai:
 		if config.Project.Repository != "test/repo" {
 			t.Errorf("Expected repository 'test/repo', got %s", config.Project.Repository)
 		}
-		if config.Output.Wiki.Platform != "notion" {
-			t.Errorf("Expected wiki platform 'notion', got %s", config.Output.Wiki.Platform)
+		if config.Output.Wiki.Platform != "github" {
+			t.Errorf("Expected wiki platform 'github', got %s", config.Output.Wiki.Platform)
 		}
 		if config.AI.Provider != "anthropic" {
 			t.Errorf("Expected AI provider 'anthropic', got %s", config.AI.Provider)

--- a/services/ai/app/core/config.py
+++ b/services/ai/app/core/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     
     # AI Model Configuration
     default_openai_model: str = Field(default="gpt-4", description="Default OpenAI model")
-    default_anthropic_model: str = Field(default="claude-3-sonnet-20240229", description="Default Anthropic model")
+    default_anthropic_model: str = Field(default="claude-3-5-sonnet-20241022", description="Default Anthropic model")
     max_tokens: int = Field(default=4000, description="Maximum tokens for AI responses")
     temperature: float = Field(default=0.7, description="AI model temperature")
     


### PR DESCRIPTION
## 概要
コードベースからサポートされていないNotion/Confluenceプラットフォームオプションを削除し、GitHub Wikiのみをサポートする構成に簡素化しました。

## 変更内容
- **README.md**: アーキテクチャ図とストレージオプションからNotion/Confluence削除
- **beaver.yml.example**: プラットフォームコメントを簡素化
- **config.go**: バリデーションからNotion/Confluenceプラットフォーム削除  
- **config_test.go**: サポートされていないプラットフォームのテストケース削除
- **config.py**: Claude モデルを最新版に更新 (claude-3-5-sonnet-20241022)

## テスト
- ✅ 全テストが正常に通過
- ✅ 品質チェック (lint, format, test) 完了
- ✅ 設定ファイルバリデーション正常動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)