### PR TITLE
fix: GitHub Pages 404エラーの修正 - Jekyll theme設定の統一

### DIFF
--- a/scripts/ci-beaver.sh
+++ b/scripts/ci-beaver.sh
@@ -400,10 +400,24 @@ execute_github_pages() {
     local jekyll_theme="${THEME:-minima}"
     local search_enabled="${ENABLE_SEARCH:-false}"
     
+    # Set appropriate remote theme based on theme parameter
+    local remote_theme
+    case "$jekyll_theme" in
+        "minima")
+            remote_theme="minima"
+            ;;
+        "minimal")
+            remote_theme="pages-themes/minimal@v0.2.0"
+            ;;
+        *)
+            remote_theme="$jekyll_theme"
+            ;;
+    esac
+    
     cat > "_site/_config.yml" << EOF
 title: "Beaver Documentation"
 description: "AI agent knowledge dam construction tool documentation"
-remote_theme: pages-themes/minimal@v0.2.0
+remote_theme: $remote_theme
 plugins:
   - jekyll-remote-theme
   - jekyll-feed


### PR DESCRIPTION
## 概要
GitHub Pagesデプロイが成功するも404エラーが発生していた問題を修正

## 変更内容
- ci-beaver.shでthemeパラメータが正しく適用されていなかった問題を修正
- workflowは--theme "minima"を指定するが、scriptは"pages-themes/minimal@v0.2.0"をハードコード
- theme設定を動的に選択するロジックを追加：
  - "minima" → remote_theme: minima
  - "minimal" → remote_theme: pages-themes/minimal@v0.2.0
  - その他 → remote_theme: そのまま使用

## テスト
- Jekyll設定の動的生成を確認
- ci-beaver.shのdry-runモードでテスト済み
- 正しいtheme設定が_config.ymlに反映されることを確認

Closes #300