### PR TITLE
fix: GitHub Actions リリースワークフロー重複エラーの修正

### DIFF
--- a/scripts/release-builder.sh
+++ b/scripts/release-builder.sh
@@ -485,6 +485,17 @@ create_github_release() {
         fi
     fi
     
+    # Check if release already exists
+    log_info "Checking if release $VERSION already exists..."
+    
+    if [[ "$DRY_RUN" != "true" ]]; then
+        if gh release view "$VERSION" >/dev/null 2>&1; then
+            log_info "Release $VERSION already exists, skipping creation"
+            log_info "Release URL: https://github.com/$REPOSITORY/releases/tag/$VERSION"
+            return 0
+        fi
+    fi
+    
     # Create the release
     log_info "Creating GitHub release: $VERSION"
     


### PR DESCRIPTION
## 概要

GitHub Actions リリースワークフローで「release with the same tag name already exists」エラーが発生する問題を修正。

## 変更内容

- `scripts/release-builder.sh` の `create_github_release()` 関数に既存リリースの確認処理を追加
- `gh release view` コマンドで既存リリースをチェック
- 既存リリースが見つかった場合はスキップして成功として処理

## 背景

GitHub UI からリリースを作成すると：
1. リリースとタグが作成される
2. タグプッシュが GitHub Actions ワークフローをトリガー
3. ワークフローが同じリリースを再作成しようとして失敗

この変更により、既存リリースが検出された場合は自動的にスキップされ、ワークフローが正常に完了します。

## テスト

- 既存リリース v0.2 での動作確認済み
- GitHub UI からのリリース作成フローとの互換性を維持

Closes #N/A (GitHub Actions エラー修正)