### PR TITLE
fix: GitHub Pages デプロイをmainブランチのみに制限

### DIFF
--- a/.github/workflows/beaver.yml
+++ b/.github/workflows/beaver.yml
@@ -145,7 +145,7 @@ jobs:
     name: 🚀 Beaver Self-Documentation (GitHub Pages)
     runs-on: ubuntu-latest
     needs: preflight
-    if: ${{ needs.preflight.outputs.should_update == 'true' }}
+    if: ${{ needs.preflight.outputs.should_update == 'true' && github.ref == 'refs/heads/main' }}
     
     environment:
       name: github-pages
@@ -283,7 +283,7 @@ jobs:
     name: 🧹 Self-Documentation Cleanup
     runs-on: ubuntu-latest
     needs: [beaver-self-documentation]
-    if: ${{ always() && (github.event_name == 'schedule' || github.event.inputs.force_rebuild == 'true') }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event.inputs.force_rebuild == 'true') && github.ref == 'refs/heads/main' }}
     
     steps:
     - name: 📥 Checkout code
@@ -327,7 +327,7 @@ jobs:
   weekly-self-analysis:
     name: 📈 Weekly Self-Analysis
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
     
     steps:
     - name: 📥 Checkout code


### PR DESCRIPTION
## 概要

フィーチャーブランチからのGitHub Pages デプロイ試行によるブランチ保護エラーを防止します。

## 変更内容

以下の条件を追加してmainブランチからのみデプロイを実行：
- `beaver-self-documentation`: `github.ref == 'refs/heads/main'`
- `self-documentation-cleanup`: `github.ref == 'refs/heads/main'`  
- `weekly-self-analysis`: `github.ref == 'refs/heads/main'`

## 効果

- プルリクエスト時の404エラー解消
- GitHub Pagesデプロイ失敗の防止
- ブランチ保護ルール遵守

## テスト

- 全テストケース通過確認済み
- プルリクエスト時にはGitHub Pagesデプロイがスキップされることを確認

Closes #304