### PR TITLE
Add check for _site directory in self-documentation job

### DIFF
--- a/.github/workflows/beaver.yml
+++ b/.github/workflows/beaver.yml
@@ -246,6 +246,7 @@ jobs:
           echo "📝 Recent Log Entries:"
           tail -n 10 .beaver/ci-beaver.log | sed 's/^/  /'
         fi
+        ls -la _sites || echo "No _site directory found - check if generation was successful"
 
     - name: 📄 Setup GitHub Pages
       uses: actions/configure-pages@v5


### PR DESCRIPTION
Implement a check to verify the existence of the _site directory during the self-documentation job, enhancing error handling for generation success.