### PR TITLE
fix: UTF-8エンコーディング問題の完全解決

### DIFF
--- a/cmd/beaver/fetch.go
+++ b/cmd/beaver/fetch.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/nyasuto/beaver/internal/config"
 	"github.com/nyasuto/beaver/internal/models"
 	"github.com/nyasuto/beaver/pkg/github"
+	"github.com/nyasuto/beaver/pkg/wiki"
 	"github.com/spf13/cobra"
 )
 
@@ -173,7 +173,7 @@ func outputJSON(result *models.IssueResult, outputFile string) error {
 	}
 
 	if outputFile != "" {
-		err = os.WriteFile(outputFile, jsonData, 0600)
+		err = wiki.WriteFileUTF8(outputFile, string(jsonData), 0600)
 		if err != nil {
 			return fmt.Errorf("❌ ファイル書き込みエラー: %w", err)
 		}
@@ -273,7 +273,7 @@ func outputSummary(result *models.IssueResult, outputFile string) error {
 	summaryText := output.String()
 
 	if outputFile != "" {
-		err := os.WriteFile(outputFile, []byte(summaryText), 0600)
+		err := wiki.WriteFileUTF8(outputFile, summaryText, 0600)
 		if err != nil {
 			return fmt.Errorf("❌ ファイル書き込みエラー: %w", err)
 		}

--- a/cmd/beaver/generate.go
+++ b/cmd/beaver/generate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyasuto/beaver/internal/models"
 	"github.com/nyasuto/beaver/pkg/github"
 	"github.com/nyasuto/beaver/pkg/troubleshooting"
+	"github.com/nyasuto/beaver/pkg/wiki"
 	"github.com/spf13/cobra"
 )
 
@@ -219,7 +220,7 @@ func saveTroubleshootingJSON(guide *troubleshooting.TroubleshootingGuide, filena
 		return fmt.Errorf("failed to marshal guide to JSON: %w", err)
 	}
 
-	err = os.WriteFile(filename, data, 0600)
+	err = wiki.WriteFileUTF8(filename, string(data), 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write JSON file: %w", err)
 	}
@@ -231,7 +232,7 @@ func saveTroubleshootingJSON(guide *troubleshooting.TroubleshootingGuide, filena
 func saveTroubleshootingWiki(guide *troubleshooting.TroubleshootingGuide, filename string) error {
 	content := generateTroubleshootingWikiContent(guide)
 
-	err := os.WriteFile(filename, []byte(content), 0600)
+	err := wiki.WriteFileUTF8(filename, content, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write wiki file: %w", err)
 	}

--- a/pkg/wiki/file_manager.go
+++ b/pkg/wiki/file_manager.go
@@ -78,15 +78,15 @@ func sanitizeUTF8Content(content string) string {
 func WriteFileUTF8(filename string, content string, perm os.FileMode) error {
 	// Sanitize content to ensure valid UTF-8
 	sanitizedContent := sanitizeUTF8Content(content)
-	
+
 	// Convert to bytes - Go strings are already UTF-8 encoded
 	contentBytes := []byte(sanitizedContent)
-	
+
 	// Verify the byte sequence is valid UTF-8
 	if !utf8.Valid(contentBytes) {
 		return fmt.Errorf("content contains invalid UTF-8 sequences after sanitization")
 	}
-	
+
 	// Write the file
 	return os.WriteFile(filename, contentBytes, perm)
 }
@@ -292,7 +292,7 @@ func (fm *WikiFileManager) WritePageFile(title, content string) (*FileInfo, erro
 	} else {
 		err = os.WriteFile(finalPath, []byte(content), 0600)
 	}
-	
+
 	if err != nil { // #nosec G306 -- Wiki files need appropriate read permissions
 		return nil, NewWikiError(ErrorTypeFileSystem, "write_page", err,
 			"ページファイルの書き込みに失敗しました", 0,

--- a/pkg/wiki/file_manager.go
+++ b/pkg/wiki/file_manager.go
@@ -73,6 +73,24 @@ func sanitizeUTF8Content(content string) string {
 	return buf.String()
 }
 
+// WriteFileUTF8 writes content to a file with UTF-8 encoding guarantee
+// This function ensures that all content is properly encoded as UTF-8
+func WriteFileUTF8(filename string, content string, perm os.FileMode) error {
+	// Sanitize content to ensure valid UTF-8
+	sanitizedContent := sanitizeUTF8Content(content)
+	
+	// Convert to bytes - Go strings are already UTF-8 encoded
+	contentBytes := []byte(sanitizedContent)
+	
+	// Verify the byte sequence is valid UTF-8
+	if !utf8.Valid(contentBytes) {
+		return fmt.Errorf("content contains invalid UTF-8 sequences after sanitization")
+	}
+	
+	// Write the file
+	return os.WriteFile(filename, contentBytes, perm)
+}
+
 // NewWikiFileManager creates a new file manager instance
 func NewWikiFileManager(workDir string) *WikiFileManager {
 	return &WikiFileManager{
@@ -268,14 +286,14 @@ func (fm *WikiFileManager) WritePageFile(title, content string) (*FileInfo, erro
 		return nil, err
 	}
 
-	// Ensure UTF-8 encoding
+	// Write file with UTF-8 encoding guarantee
 	if fm.config.UseUTF8Encoding {
-		content = sanitizeUTF8Content(content)
+		err = WriteFileUTF8(finalPath, content, 0600)
+	} else {
+		err = os.WriteFile(finalPath, []byte(content), 0600)
 	}
-	contentBytes := []byte(content)
-
-	// Write file with appropriate permissions
-	if err := os.WriteFile(finalPath, contentBytes, 0600); err != nil { // #nosec G306 -- Wiki files need appropriate read permissions
+	
+	if err != nil { // #nosec G306 -- Wiki files need appropriate read permissions
 		return nil, NewWikiError(ErrorTypeFileSystem, "write_page", err,
 			"ページファイルの書き込みに失敗しました", 0,
 			[]string{

--- a/pkg/wiki/github_pages_publisher.go
+++ b/pkg/wiki/github_pages_publisher.go
@@ -206,14 +206,14 @@ func (p *GitHubPagesPublisher) createInitialJekyllStructure() error {
 	// Create _config.yml
 	configContent := p.generateJekyllConfig()
 	configPath := filepath.Join(p.workingDir, "_config.yml")
-	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+	if err := WriteFileUTF8(configPath, configContent, 0600); err != nil {
 		return fmt.Errorf("failed to create _config.yml: %w", err)
 	}
 
 	// Create initial index.md
 	indexContent := p.generateInitialIndex()
 	indexPath := filepath.Join(p.workingDir, "index.md")
-	if err := os.WriteFile(indexPath, []byte(indexContent), 0600); err != nil {
+	if err := WriteFileUTF8(indexPath, indexContent, 0600); err != nil {
 		return fmt.Errorf("failed to create index.md: %w", err)
 	}
 
@@ -226,7 +226,7 @@ func (p *GitHubPagesPublisher) createInitialJekyllStructure() error {
 	// Create default layout
 	defaultLayoutContent := p.generateDefaultLayout()
 	defaultLayoutPath := filepath.Join(layoutsDir, "default.html")
-	if err := os.WriteFile(defaultLayoutPath, []byte(defaultLayoutContent), 0600); err != nil {
+	if err := WriteFileUTF8(defaultLayoutPath, defaultLayoutContent, 0600); err != nil {
 		return fmt.Errorf("failed to create default layout: %w", err)
 	}
 
@@ -462,7 +462,7 @@ func (p *GitHubPagesPublisher) convertAndSaveWikiPage(page *WikiPage) error {
 	filePath := filepath.Join(p.workingDir, filename)
 
 	// Write the file
-	if err := os.WriteFile(filePath, []byte(jekyllContent), 0600); err != nil {
+	if err := WriteFileUTF8(filePath, jekyllContent, 0600); err != nil {
 		return fmt.Errorf("failed to write Jekyll page %s: %w", filePath, err)
 	}
 

--- a/scripts/ci-beaver.sh
+++ b/scripts/ci-beaver.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+# Force UTF-8 encoding for all operations
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
 # Script configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"


### PR DESCRIPTION
## 概要

Jekyll buildでのUTF-8エラーを解決するため包括的なUTF-8対応を実装

## 変更内容

### コア機能追加
- **`pkg/wiki/file_manager.go`**: `WriteFileUTF8`関数を追加
  - UTF-8サニタイゼーション機能強化
  - 無効なUTF-8シーケンスの自動修正
  - ファイル書き込み前のUTF-8検証

### ファイル書き込み操作の統一
- **`cmd/beaver/generate.go`**: JSONおよびWikiファイル出力を`WriteFileUTF8`に変更
- **`cmd/beaver/fetch.go`**: 全てのファイル出力操作をUTF-8対応に更新
- **`pkg/wiki/github_pages_publisher.go`**: Jekyll設定ファイル等の書き込みをUTF-8保証

### CI/CD環境対応
- **`scripts/ci-beaver.sh`**: `LC_ALL=C.UTF-8`と`LANG=C.UTF-8`を設定
  - GitHub Actions環境でのUTF-8強制設定
  - クロスプラットフォーム互換性確保

## 解決する問題

この変更により以下のJekyllエラーが解決されます：

- `Error reading file /github/workspace/_site/beaver-Development-Strategy.md: invalid byte sequence in UTF-8`
- `Error reading file /github/workspace/_site/beaver-Issues-Summary.md: invalid byte sequence in UTF-8`
- `Error reading file /github/workspace/_site/beaver-Learning-Path.md: invalid byte sequence in UTF-8`
- `Jekyll::Converters::Markdown encountered an error while converting 'beaver-Development-Strategy.md': The source text contains invalid characters for the used encoding UTF-8`

## テスト

- ✅ 全テストが通過
- ✅ pre-commitフックでコード品質チェック通過
- ✅ リントおよびセキュリティチェック通過

Closes #284

🤖 Generated with [Claude Code](https://claude.ai/code)