### PR TITLE
fix: CSS path for GitHub Pages compatibility

### DIFF
--- a/pkg/site/generator.go
+++ b/pkg/site/generator.go
@@ -206,7 +206,7 @@ func (g *HTMLGenerator) createInlineTemplates() error {
 <head>
     <meta charset="utf-8">
     <title>{{ .Title }}</title>
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
     <header class="header">
@@ -251,7 +251,7 @@ func (g *HTMLGenerator) createInlineTemplates() error {
 <head>
     <meta charset="utf-8">
     <title>{{ .Title }}</title>
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
     <header class="header">
@@ -294,7 +294,7 @@ func (g *HTMLGenerator) createInlineTemplates() error {
 <head>
     <meta charset="utf-8">
     <title>{{ .Title }}</title>
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
     <header class="header">
@@ -329,7 +329,7 @@ func (g *HTMLGenerator) createInlineTemplates() error {
 <head>
     <meta charset="utf-8">
     <title>{{ .Title }}</title>
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
     <header class="header">


### PR DESCRIPTION
## 概要

GitHub Pages でのCSS読み込み問題を修正し、Beaver ブランドテーマの適切な表示を実現。

## 変更内容

**CSS パス修正:**
- 絶対パス `/assets/css/style.css` から相対パス `assets/css/style.css` に変更
- GitHub Pages の静的サイト配信仕様に対応
- 全テンプレート（home, issues, strategy, troubleshooting）で統一修正

## 技術的詳細

**問題の原因:**
- GitHub Pages は絶対パス `/assets/` で CSS ファイルにアクセスできない
- ローカル開発では動作するが、GitHub Pages 配信時に CSS が読み込まれない

**修正内容:**
```html
<\!-- 修正前 (動作しない) -->
<link rel="stylesheet" href="/assets/css/style.css">

<\!-- 修正後 (正常動作) -->
<link rel="stylesheet" href="assets/css/style.css">
```

## 期待される効果

- ✅ Beaver ブランドカラー（茶色・青・緑）の適切な表示
- ✅ CSS Grid レイアウトの正常動作
- ✅ 日本語フォント（Noto Sans JP）の適用
- ✅ レスポンシブデザインの有効化
- ✅ カード型レイアウトとグラデーション効果

## テスト

- ✅ ローカル HTML 生成テスト完了
- ✅ CSS パス相対化確認済み
- ✅ 全テンプレート修正確認済み
- ✅ 品質チェック完了（0 lint issues）

この修正により、https://nyasuto.github.io/beaver/ で Beaver の美しいブランドテーマが正しく表示されます。