### PR TITLE
fix: mainブランチでContinuous Integrationワークフローを有効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: 🔄 Continuous Integration
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## 概要

mainブランチへのpush時にContinuous Integrationワークフローが実行されるよう修正。

## 問題

現在のCI設定では、PRとmanual triggerのみに対応しており、mainブランチへのpush時にCIが実行されない状況でした。

## 修正内容

- `.github/workflows/ci.yml`の`on`セクションに`push`トリガーを追加
- mainブランチのみを対象とするよう設定

## 変更内容

```yaml
on:
  pull_request:
  push:
    branches: [main]  # 新規追加
  workflow_dispatch:
```

## テスト

- ローカルで設定変更を確認
- pre-commitフックによる品質チェック通過

## 期待効果

- mainブランチにマージ後、自動的にCIが実行される
- コード品質とビルドの継続的な検証が可能になる

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>