### PR TITLE
feat: Go内蔵HTML生成によるMarkdown→HTML変換の実装

### DIFF
--- a/.github/workflows/beaver.yml
+++ b/.github/workflows/beaver.yml
@@ -225,7 +225,7 @@ jobs:
           # Create clean state directory
           mkdir -p .beaver
 
-          # Generate site content using Beaver's Wiki generator (Issue #367 developer dashboard) with error handling
+          # Generate site content using Beaver's built-in HTML generator
           set +e
           ./bin/beaver build --force-rebuild 
           build_exit_code=$?
@@ -242,12 +242,11 @@ jobs:
             echo "<html><head><title>Beaver Knowledge Base</title></head><body><h1>Beaver Knowledge Base</h1><p>サイト生成中にエラーが発生しました。</p></body></html>" > _site/index.html
             echo "🔄 Created fallback site content"
           else
-            echo "✅ Beaver build successful, checking generated content"
+            echo "✅ Beaver build successful with Go HTML generator"
             
-            # Check if _site directory was created by beaver build
+            # Beaver now generates _site directory with HTML files directly
             if [ -d "_site" ]; then
-              echo "📁 Using Beaver-generated content from _site/"
-              # _site directory already exists with generated content
+              echo "📁 Using Beaver-generated HTML content from _site/"
               ls -la _site/
               
               # Add any missing assets if they exist in root
@@ -256,69 +255,11 @@ jobs:
                 echo "  ✅ Added assets directory to _site/"
               fi
             else
-              echo "📁 No _site directory found, converting Markdown to HTML"
-              # Create _site directory structure
-              mkdir -p _site
-              
-              # Convert new Markdown files to HTML for GitHub Pages
-              echo "🔄 Converting Beaver-generated Markdown to HTML..."
-              
-              # Convert beaver-Home.md to index.html
-              if [ -f "beaver-Home.md" ]; then
-                echo "  🔄 Converting beaver-Home.md -> index.html"
-                # Simple MD to HTML conversion (preserving structure)
-                {
-                  echo '<!DOCTYPE html>'
-                  echo '<html lang="ja">'
-                  echo '<head>'
-                  echo '    <meta charset="UTF-8">'
-                  echo '    <meta name="viewport" content="width=device-width, initial-scale=1.0">'
-                  echo '    <title>Beaver Knowledge Base</title>'
-                  echo '    <link rel="stylesheet" href="assets/css/style.css">'
-                  echo '</head>'
-                  echo '<body>'
-                  echo '    <header>'
-                  echo '        <h1>🦫 Beaver - AIエージェント知識ダム構築ツール - Developer Dashboard</h1>'
-                  # Extract timestamp from beaver-Home.md
-                  timestamp=$(grep "Generated" beaver-Home.md | sed 's/.*Generated //' | head -1)
-                  echo "        <p>🎯 <strong>30秒で情報発見</strong> - 開発者ワークフロー最適化ダッシュボード | Generated $timestamp</p>"
-                  echo '    </header>'
-                  echo '    <main>'
-                  
-                  # Convert markdown content to basic HTML
-                  sed -e 's/^# /<h1>/' -e 's/$/<\/h1>/' \
-                      -e 's/^## /<h2>/' -e 's/$/<\/h2>/' \
-                      -e 's/^### /<h3>/' -e 's/$/<\/h3>/' \
-                      -e 's/^\*\*\([^*]*\)\*\*/<strong>\1<\/strong>/g' \
-                      -e 's/\[\([^]]*\)\](\([^)]*\))/<a href="\2">\1<\/a>/g' \
-                      -e 's/^$/\<br\/\>/' \
-                      beaver-Home.md | grep -v "^# " | tail -n +4
-                  
-                  echo '    </main>'
-                  echo '    <script src="assets/js/main.js"></script>'
-                  echo '</body>'
-                  echo '</html>'
-                } > _site/index.html
-                echo "  ✅ Generated index.html with latest timestamp: $timestamp"
-              else
-                echo "  ⚠️ beaver-Home.md not found, using fallback HTML files"
-                # Fallback: Copy existing HTML files
-                for html_file in *.html; do
-                  if [ -f "$html_file" ]; then
-                    cp "$html_file" "_site/"
-                    echo "  ✅ Copied $html_file -> _site/$html_file"
-                  fi
-                done
-              fi
-              
-              # Copy assets directory if it exists
-              if [ -d "assets" ]; then
-                cp -r assets "_site/"
-                echo "  ✅ Copied assets directory"
-              fi
+              echo "❌ No _site directory found - Beaver HTML generation may have failed"
+              exit 1
             fi
             
-            echo "🔧 GitHub Pages content prepared"
+            echo "🔧 GitHub Pages content prepared by Go generator"
           fi
             
           echo "✅ GitHub Pages content generated successfully"

--- a/cmd/beaver/main.go
+++ b/cmd/beaver/main.go
@@ -265,7 +265,36 @@ func runBuildCommand(cmd *cobra.Command, args []string) error {
 	}
 	buildLogger.Info("Wiki content generated", "page_count", len(wikiPages))
 
-	// Save Wiki pages
+	// Generate HTML pages for GitHub Pages
+	buildLogger.Info("Generating HTML pages for GitHub Pages")
+	fmt.Printf("🌐 HTML生成中...\n")
+	htmlPages, err := wikiGenerator.GenerateHTMLPages(issuesForProcessing, cfg.Project.Name)
+	if err != nil {
+		buildLogger.Error("Failed to generate HTML pages", "error", err)
+		return fmt.Errorf("❌ HTML生成エラー: %w", err)
+	}
+	buildLogger.Info("HTML pages generated", "page_count", len(htmlPages))
+
+	// Create _site directory if it doesn't exist
+	siteDir := "_site"
+	if err := os.MkdirAll(siteDir, 0755); err != nil {
+		buildLogger.Error("Failed to create _site directory", "error", err)
+		return fmt.Errorf("❌ _siteディレクトリ作成エラー: %w", err)
+	}
+
+	// Save HTML pages to _site directory
+	buildLogger.Info("Saving HTML pages to _site directory")
+	for _, page := range htmlPages {
+		outputPath := fmt.Sprintf("%s/%s", siteDir, page.Filename)
+		if err := os.WriteFile(outputPath, []byte(page.Content), 0600); err != nil {
+			buildLogger.Error("Failed to save HTML page", "error", err, "output_path", outputPath)
+			return fmt.Errorf("❌ HTMLページ保存エラー: %w", err)
+		}
+		buildLogger.Info("HTML page saved", "output_path", outputPath, "size_bytes", len(page.Content))
+		fmt.Printf("✅ HTMLページ生成完了: %s\n", outputPath)
+	}
+
+	// Save Wiki pages (markdown files)
 	buildLogger.Info("Saving Wiki pages")
 	var totalSize int
 	for _, page := range wikiPages {
@@ -318,7 +347,8 @@ func runBuildCommand(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("📄 総ファイルサイズ: %.2f KB\n", float64(totalSize)/1024)
 	fmt.Printf("📊 処理したIssues: %d件\n", len(issuesForProcessing))
-	fmt.Printf("📝 生成したページ: %d件\n", len(wikiPages))
+	fmt.Printf("📝 生成したページ: %d件 (Markdown)\n", len(wikiPages))
+	fmt.Printf("🌐 生成したページ: %d件 (HTML)\n", len(htmlPages))
 
 	fmt.Println("🦫 Beaver Build完了!")
 	buildLogger.Info("Build command completed successfully")

--- a/pkg/wiki/generator.go
+++ b/pkg/wiki/generator.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/nyasuto/beaver/internal/config"
@@ -47,6 +49,15 @@ type WikiPage struct {
 	Summary   string
 	Category  string
 	Tags      []string
+}
+
+// HTMLPage represents a generated HTML page
+type HTMLPage struct {
+	Title     string
+	Content   string // HTML content
+	Filename  string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // ClassificationSummary contains classification statistics
@@ -1241,4 +1252,159 @@ func (g *Generator) GenerateDeveloperDashboard(issues []models.Issue, projectNam
 		Category:  "Dashboard",
 		Tags:      []string{"dashboard", "urgent", "developer", "quick-access"},
 	}, nil
+}
+
+// GenerateHTMLPages generates HTML pages directly from markdown templates
+func (g *Generator) GenerateHTMLPages(issues []models.Issue, projectName string) ([]*HTMLPage, error) {
+	var htmlPages []*HTMLPage
+
+	// Generate HTML version of developer dashboard (index.html)
+	dashboardPage, err := g.GenerateDeveloperDashboard(issues, projectName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate developer dashboard: %w", err)
+	}
+
+	// Convert markdown to HTML
+	htmlContent := g.convertMarkdownToHTML(dashboardPage.Content, dashboardPage.Title)
+
+	htmlPages = append(htmlPages, &HTMLPage{
+		Title:     dashboardPage.Title,
+		Content:   htmlContent,
+		Filename:  "index.html",
+		CreatedAt: g.now(),
+		UpdatedAt: g.now(),
+	})
+
+	return htmlPages, nil
+}
+
+// convertMarkdownToHTML converts markdown content to HTML with proper structure
+func (g *Generator) convertMarkdownToHTML(markdown, title string) string {
+	timestamp := g.now().Format("2006-01-02 15:04")
+
+	html := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>%s</title>
+    <link rel="stylesheet" href="assets/css/style.css">
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 20px; background: #f5f5f5; }
+        .container { max-width: 1200px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        header { background: linear-gradient(135deg, #667eea 0%%, #764ba2 100%%); color: white; padding: 30px; border-radius: 8px; margin-bottom: 30px; text-align: center; }
+        h1 { margin: 0; font-size: 2em; }
+        h2 { color: #333; border-bottom: 2px solid #667eea; padding-bottom: 10px; margin-top: 30px; }
+        h3 { color: #555; margin-top: 25px; }
+        table { width: 100%%; border-collapse: collapse; margin: 20px 0; }
+        table, th, td { border: 1px solid #ddd; }
+        th, td { padding: 12px; text-align: left; }
+        th { background-color: #f8f9fa; font-weight: 600; }
+        tr:nth-child(even) { background-color: #f8f9fa; }
+        a { color: #667eea; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        strong { color: #333; }
+        hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }
+        .urgent-section { background: #fff5f5; border-left: 4px solid #f56565; padding: 20px; margin: 20px 0; border-radius: 4px; }
+        .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; margin: 20px 0; }
+        .stat-card { background: #f8f9fa; padding: 20px; border-radius: 8px; text-align: center; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🦫 Beaver - AIエージェント知識ダム構築ツール - Developer Dashboard</h1>
+            <p>🎯 <strong>30秒で情報発見</strong> - 開発者ワークフロー最適化ダッシュボード | Generated %s</p>
+        </header>
+        <main>
+%s
+        </main>
+    </div>
+    <script src="assets/js/main.js"></script>
+</body>
+</html>`, title, timestamp, g.markdownToHTMLContent(markdown))
+
+	return html
+}
+
+// markdownToHTMLContent converts markdown content to HTML
+func (g *Generator) markdownToHTMLContent(markdown string) string {
+	// Split into lines for processing
+	lines := strings.Split(markdown, "\n")
+	var htmlLines []string
+	inTable := false
+
+	for i, line := range lines {
+		// Skip the main title and blockquote metadata (already in HTML header)
+		if i == 0 && strings.HasPrefix(line, "# ") {
+			continue
+		}
+		if i <= 3 && (strings.HasPrefix(line, "> ") || strings.TrimSpace(line) == "") {
+			continue
+		}
+
+		// Headers
+		if strings.HasPrefix(line, "### ") {
+			htmlLines = append(htmlLines, fmt.Sprintf("<h3>%s</h3>", strings.TrimPrefix(line, "### ")))
+		} else if strings.HasPrefix(line, "## ") {
+			htmlLines = append(htmlLines, fmt.Sprintf("<h2>%s</h2>", strings.TrimPrefix(line, "## ")))
+		} else if strings.HasPrefix(line, "# ") {
+			htmlLines = append(htmlLines, fmt.Sprintf("<h1>%s</h1>", strings.TrimPrefix(line, "# ")))
+			// Tables
+		} else if strings.HasPrefix(line, "|") && strings.HasSuffix(line, "|") {
+			if !inTable {
+				htmlLines = append(htmlLines, "<table>")
+				inTable = true
+			}
+			if !strings.Contains(line, "---") { // Skip separator lines
+				cells := strings.Split(strings.Trim(line, "|"), "|")
+				var htmlCells []string
+				for _, cell := range cells {
+					htmlCells = append(htmlCells, fmt.Sprintf("<td>%s</td>", strings.TrimSpace(cell)))
+				}
+				htmlLines = append(htmlLines, fmt.Sprintf("<tr>%s</tr>", strings.Join(htmlCells, "")))
+			}
+		} else {
+			if inTable {
+				htmlLines = append(htmlLines, "</table>")
+				inTable = false
+			}
+
+			// Horizontal rules
+			if line == "---" {
+				htmlLines = append(htmlLines, "<hr>")
+				// Blockquotes
+			} else if strings.HasPrefix(line, "> ") {
+				htmlLines = append(htmlLines, fmt.Sprintf("<blockquote>%s</blockquote>", strings.TrimPrefix(line, "> ")))
+				// Empty lines
+			} else if strings.TrimSpace(line) == "" {
+				htmlLines = append(htmlLines, "<br>")
+				// Regular content with inline formatting
+			} else {
+				formatted := g.formatInlineMarkdown(line)
+				htmlLines = append(htmlLines, fmt.Sprintf("<p>%s</p>", formatted))
+			}
+		}
+	}
+
+	// Close table if still open
+	if inTable {
+		htmlLines = append(htmlLines, "</table>")
+	}
+
+	return strings.Join(htmlLines, "\n")
+}
+
+// formatInlineMarkdown handles bold, links, and other inline formatting
+func (g *Generator) formatInlineMarkdown(text string) string {
+	// Bold text - handle multiple patterns
+	text = regexp.MustCompile(`\*\*([^*]+?)\*\*`).ReplaceAllString(text, "<strong>$1</strong>")
+
+	// Links
+	text = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`).ReplaceAllString(text, `<a href="$2">$1</a>`)
+
+	// Clean up any remaining bold formatting issues
+	text = regexp.MustCompile(`\*\*`).ReplaceAllString(text, "")
+
+	return text
 }


### PR DESCRIPTION
## 概要

GitHub ActionsでのshellスクリプトによるMarkdown変換を廃止し、Go内でHTML生成を直接実行する方式に変更。

## 主な変更点

### pkg/wiki/generator.go
- HTMLページ生成機能 (GenerateHTMLPages) を追加
- 自作のMarkdown→HTML変換ロジックを実装
- カスタムCSSとレスポンシブデザインを内蔵
- テーブル、太字、リンク、ヘッダーの変換に対応

### cmd/beaver/main.go  
- HTML生成処理を追加 (_site/index.html)
- MarkdownとHTML両方のファイル生成
- 詳細な生成ログとサイズ情報の出力
- ファイル権限をセキュリティ要件に適合 (0600)

### .github/workflows/beaver.yml
- 複雑なsed/awkスクリプトを削除
- Beaverが生成する_siteディレクトリを直接使用
- シンプルで保守しやすい処理に変更

## 技術的改善
- **処理の集約**: Markdown変換がGo内で完結
- **保守性向上**: shellスクリプトの複雑性を排除  
- **テスト可能性**: Go内でのユニットテスト対応
- **エラーハンドリング**: 構造化されたエラー処理

## 今後の検討事項
goldmark/blackfridayライブラリとの比較調査を予定

## Test plan
- [x] ローカルビルドが正常に動作
- [x] HTML生成機能のテスト完了
- [x] 全ユニットテストが通過
- [x] 既存機能への影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)