### PR TITLE
fix: フレックスボックスレイアウト実装 - TOC展開時のコンテンツシフト問題解決

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -33,12 +33,19 @@ body {
     position: relative;
 }
 
+/* コンテンツラッパー（ヘッダー後のコンテンツ） */
+.content-wrapper {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
 /* メインコンテンツエリア */
 main {
-    clear: both;
+    flex: 1;
     padding-top: 20px;
-    margin-right: 320px; /* 目次サイドバー分のマージン確保 */
     min-height: 500px; /* 最小高度確保 */
+    order: 1;
 }
 
 /* ===== ヘッダー ===== */
@@ -253,9 +260,9 @@ pre code {
 .table-of-contents {
     position: sticky;
     top: 20px;
-    float: right;
     width: 280px;
-    margin: 0 0 20px 20px;
+    flex-shrink: 0;
+    order: 2;
     background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
     border: 1px solid #e0e0e0;
     border-radius: 10px;
@@ -479,18 +486,23 @@ pre code {
         padding: 15px; 
     }
     
+    /* フレックスボックスレイアウトのタブレット対応 */
+    .content-wrapper {
+        flex-direction: column;
+    }
+    
     /* 目次のタブレット対応 */
     .table-of-contents {
         position: static;
-        float: none;
         width: 100%;
+        order: 2;
         margin: 20px 0;
         max-height: none;
     }
     
     /* メインエリアのタブレット対応 */
     main {
-        margin-right: 0; /* サイドバーマージン解除 */
+        order: 1;
     }
     
     .toc-list {
@@ -562,15 +574,21 @@ pre code {
         word-break: break-all;
     }
     
+    /* フレックスボックスレイアウトのモバイル対応 */
+    .content-wrapper {
+        flex-direction: column;
+    }
+    
     /* 目次のモバイル対応 */
     .table-of-contents {
         margin: 15px 0;
         border-radius: 6px;
+        order: 2;
     }
     
     /* メインエリアのモバイル対応 */
     main {
-        margin-right: 0; /* サイドバーマージン解除 */
+        order: 1;
     }
     
     .toc-header {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // ===== TIMESTAMPS =====
     initializeTimestamps();
     
+    
     console.log('🦫 Beaver Knowledge Base fully initialized');
 });
 
@@ -298,6 +299,7 @@ function initializeTimestamps() {
         }
     });
 }
+
 
 /**
  * Utility Functions


### PR DESCRIPTION
## 概要

GitHub Pagesサイトのレイアウト問題を修正し、TOC（目次）の展開/折りたたみ時にメインコンテンツがシフトする問題を解決しました。

## 変更内容

### CSSレイアウト改善
- **float-basedからflexbox-basedレイアウトに移行**
  - `.content-wrapper`でflexboxコンテナを作成
  - メインコンテンツとTOCを適切に配置
- **メインコンテンツエリアの初期表示問題を解決**
  - 以前は`margin-right: 320px`によりコンテンツが初期状態で見えなかった
  - flexbox使用によりコンテンツが最初から表示される
- **TOC展開/折りたたみ時のコンテンツシフトを防止**
  - TOCの高さ変更が他の要素に影響しないように修正

### レスポンシブ対応強化
- **タブレット/モバイル環境での改善**
  - `flex-direction: column`で縦並びレイアウトに変更
  - `order`プロパティで要素の順序を適切に制御
- **全デバイスでの表示安定性を向上**

### 技術的改善詳細
```css
/* 新しいflexboxレイアウト */
.content-wrapper {
    display: flex;
    gap: 20px;
    align-items: flex-start;
}

main {
    flex: 1;
    order: 1;
}

.table-of-contents {
    width: 280px;
    flex-shrink: 0;
    order: 2;
}
```

## テスト

- ローカル環境でHTTP serverを起動して動作確認済み
- MCP Playwrightによる自動テスト実行済み
- TOC展開/折りたたみ動作でコンテンツシフトが発生しないことを確認
- レスポンシブ対応の動作確認済み

## 解決した問題

1. **初期表示問題**: メイン画面が真っ白に見える問題
2. **TOC展開問題**: naviで目次が広がるとメインコンテンツが下にスクロールする問題
3. **レイアウト安定性**: 動的なコンテンツ変更への対応

🤖 Generated with [Claude Code](https://claude.ai/code)