### PR TITLE
fix: 自己文書化ワークフローの並列実行を直列実行に修正

### DIFF
--- a/.github/workflows/beaver.yml
+++ b/.github/workflows/beaver.yml
@@ -11,6 +11,17 @@ permissions:
   pages: write
   id-token: write
 
+# Ensure only one self-documentation workflow runs at a time to prevent conflicts
+# When issues are updated rapidly, multiple workflows could run in parallel
+# This would cause:
+# - Git conflicts when pushing to GitHub Pages
+# - Resource contention during site generation
+# - Inconsistent incremental state management
+# Solution: Serialize execution with cancel-in-progress: false to queue subsequent runs
+concurrency:
+  group: beaver-self-documentation
+  cancel-in-progress: false
+
 on:
   # Issue events - create, update, close, reopen
   issues:


### PR DESCRIPTION
## 概要

Issue連続更新時の自己文書化ワークフロー並列実行問題を解決。concurrency設定により直列実行を実現し、競合状態を防止。

## 課題

- **並列実行問題**: Issue連続更新時に複数の自己文書化ワークフローが同時実行される
- **競合リスク**: GitHub Pagesへのpush競合、リソース衝突の可能性
- **状態管理問題**: 増分状態管理ファイルの不整合リスク

## 解決策

- **concurrency設定追加**: ワークフローの同時実行を制御
- **group指定**: `beaver-self-documentation`で同一グループ化
- **キューイング**: `cancel-in-progress: false`で後続実行をキューに保持
- **安全性確保**: Git競合とリソース衝突を完全防止

## 技術詳細

```yaml
concurrency:
  group: beaver-self-documentation
  cancel-in-progress: false
```

これにより、Issue更新が連続で発生しても：
1. 最初のワークフローが完了するまで後続は待機
2. 全ての更新が確実に処理される
3. GitHub Pages deploymentが安全に実行される

## テスト

- ✅ YAML構文検証完了
- ✅ 品質チェック（make quality）通過  
- ✅ 全単体テスト通過

Closes #(Issue番号は手動で追加してください)