### PR TITLE
fix: dependabot設定からpipとdocker管理を削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,30 +9,13 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
 
-  # Python依存関係の自動更新 (Poetry)
-  - package-ecosystem: "pip"
-    directory: "/services/ai"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:30"
-      timezone: "Asia/Tokyo"
-  # Docker依存関係の自動更新
-  - package-ecosystem: "docker"
-    directory: "/services/ai"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "10:00"
-      timezone: "Asia/Tokyo"
-
   # npm依存関係の自動更新 (Astro frontend)
   - package-ecosystem: "npm"
     directory: "/frontend/astro"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "10:00"
+      time: "09:30"
       timezone: "Asia/Tokyo"
 
   # GitHub Actions の自動更新


### PR DESCRIPTION
## 概要

不要になったPythonとDocker依存関係管理をdependabot設定から削除し、現在のプロジェクト構成に合わせて最適化する。

## 変更内容

### 削除項目
- **Python/pip依存関係管理**: services/ai ディレクトリ廃止のため削除
- **Docker依存関係管理**: Docker使用終了のため削除

### 調整項目
- **npm管理時間**: 10:00 → 09:30 (時間重複解消)

## 現在の管理対象

| 依存関係 | ディレクトリ | 時間 | 説明 |
|----------|--------------|------|------|
| Go modules | `/` | 09:00 | メインアプリケーション |
| npm | `/frontend/astro` | 09:30 | Astro frontend |
| GitHub Actions | `/` | 10:30 | CI/CD workflow |

## テスト

- ✅ 品質チェック完了: `make quality` 成功
- ✅ 設定ファイル構文正常
- ✅ 既存のdependabot npm PRが正常動作中

🤖 Generated with [Claude Code](https://claude.ai/code)