### PR TITLE
fix: GitHub Pages 404リンク修正 - BASE_URL適用でbeaver/パス問題解決

### DIFF
--- a/frontend/astro/astro.config.mjs
+++ b/frontend/astro/astro.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
   output: 'static',
   outDir: '../../_site-astro',
   publicDir: './public',
-  base: process.env.NODE_ENV === 'production' ? '/beaver' : '',
+  base: process.env.NODE_ENV === 'production' ? '/beaver/' : '/',
   server: {
     port: 4321,
     host: true

--- a/frontend/astro/src/layouts/BaseLayout.astro
+++ b/frontend/astro/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ const { title, description = "Beaver - AI知識ダム" } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
     <title>{title}</title>
     
     <!-- Performance optimizations -->
@@ -43,10 +43,10 @@ const { title, description = "Beaver - AI知識ダム" } = Astro.props;
               </h1>
             </div>
             <nav class="flex items-center space-x-4">
-              <a href="/" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
+              <a href={import.meta.env.BASE_URL} class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
                 ホーム
               </a>
-              <a href="/issues" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
+              <a href={`${import.meta.env.BASE_URL}issues`} class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
                 Issues
               </a>
             </nav>

--- a/frontend/astro/src/pages/index.astro
+++ b/frontend/astro/src/pages/index.astro
@@ -51,7 +51,7 @@ const { issues, statistics, metadata } = beaverData!;
             Experience advanced search, filtering, and real-time analytics with React Islands
           </p>
           <a 
-            href="/issues" 
+            href={`${import.meta.env.BASE_URL}issues`} 
             class="inline-flex items-center px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm"
           >
             🔍 Try Interactive Dashboard →
@@ -91,7 +91,7 @@ const { issues, statistics, metadata } = beaverData!;
         
         {issues.length > 5 && (
           <div class="mt-6 text-center">
-            <a href="/issues" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+            <a href={`${import.meta.env.BASE_URL}issues`} class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
               View All Issues ({issues.length})
             </a>
           </div>

--- a/frontend/astro/src/pages/issues.astro
+++ b/frontend/astro/src/pages/issues.astro
@@ -152,7 +152,7 @@ const { issues, statistics, metadata } = beaverData!;
     <!-- Navigation -->
     <div class="mt-8 text-center">
       <a 
-        href="/" 
+        href={import.meta.env.BASE_URL} 
         class="inline-flex items-center px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm"
       >
         ← Back to Home


### PR DESCRIPTION
## 概要

GitHub Pages環境での404リンクエラーを修正しました。リポジトリ名（`/beaver/`）がリンクパスに含まれていない問題を解決し、全てのナビゲーションリンクが正しく動作するようになりました。

## 変更内容

### 🔧 設定修正
- **astro.config.mjs**: base URLに末尾スラッシュを追加し、正しいパス生成を実現
  - `'/beaver'` → `'/beaver/'` でスラッシュ連結問題を解決

### 🔗 リンク修正
- **BaseLayout.astro**: favicon・ナビゲーションリンクにBASE_URL適用
  - favicon: `/favicon.svg` → `/beaver/favicon.svg`
  - ナビゲーション: `/`, `/issues` → `/beaver/`, `/beaver/issues`
  
- **index.astro**: ヒーローセクション・機能バナーリンクにBASE_URL適用
  - 機能バナー: `/issues` → `/beaver/issues`
  
- **issues.astro**: ホームリンクにBASE_URL適用
  - ホーム: `/` → `/beaver/`

### ⚡ 動作確認
- Astroビルド実行で正しいリンク生成を確認
- 全リンクが`/beaver/`プレフィックス付きで出力されることを検証

## テスト

- ✅ Astroビルド成功（警告・エラーなし）
- ✅ 生成HTMLで全リンクが正しい形式（`/beaver/issues`等）
- ✅ Pre-commitフック通過（Go fmt, lint, test実行）
- ✅ TypeScript型チェック通過

Closes #450