### PR TITLE
fix: 緊急タスクセクションのMarkdown表示修正 - UrgentTasks等コンポーネント対応

### DIFF
--- a/frontend/astro/src/components/InteractiveIssueList.tsx
+++ b/frontend/astro/src/components/InteractiveIssueList.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { Issue } from '../types/beaver';
+import { extractMarkdownSummary } from '../utils/markdown';
 
 interface InteractiveIssueListProps {
   issues: Issue[];
@@ -235,10 +236,7 @@ const InteractiveIssueList: React.FC<InteractiveIssueListProps> = ({
                 {viewMode === 'detailed' && issue.body && (
                   <div className="mt-2">
                     <p className="text-gray-600 dark:text-gray-400 text-sm line-clamp-2">
-                      {issue.body.length > 150 
-                        ? issue.body.substring(0, 150) + '...' 
-                        : issue.body
-                      }
+                      {extractMarkdownSummary(issue.body, 150)}
                     </p>
                   </div>
                 )}

--- a/frontend/astro/src/components/QuickSearch.tsx
+++ b/frontend/astro/src/components/QuickSearch.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import type { Issue } from '../types/beaver';
+import { extractMarkdownSummary } from '../utils/markdown';
 
 interface QuickSearchProps {
   issues: Issue[];
@@ -236,7 +237,7 @@ const QuickSearch: React.FC<QuickSearchProps> = ({ issues, className = '' }) => 
                     </h4>
                     {result.issue.body && (
                       <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
-                        {result.issue.body.slice(0, 100)}...
+                        {extractMarkdownSummary(result.issue.body, 100)}
                       </p>
                     )}
                   </div>

--- a/frontend/astro/src/components/UrgentTasks.tsx
+++ b/frontend/astro/src/components/UrgentTasks.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Issue } from '../types/beaver';
+import { extractMarkdownSummary } from '../utils/markdown';
 
 interface UrgentTasksProps {
   issues: Issue[];
@@ -163,7 +164,7 @@ const UrgentTasks: React.FC<UrgentTasksProps> = ({ issues, className = '' }) => 
                   
                   {task.body && (
                     <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
-                      {task.body.slice(0, 120)}...
+                      {extractMarkdownSummary(task.body, 120)}
                     </p>
                   )}
                   


### PR DESCRIPTION
## 概要

Recent Issuesは修正済みでしたが、緊急タスクTop3セクションでMarkdownが生のまま表示される問題を修正しました。

## 変更内容

- **UrgentTasks.tsx** - 緊急タスクTop3セクション
- **InteractiveIssueList.tsx** - 詳細ビューモード  
- **QuickSearch.tsx** - 検索結果表示

すべてのコンポーネントに`extractMarkdownSummary()`を適用し、統一されたMarkdown処理を実現。

## テスト

- フロントエンドビルド成功確認
- GitHub Pages更新済み
- 全Go テスト通過

これで全ての Issueコンテンツが適切にMarkdownパースされ、読みやすいテキストとして表示されます。

Closes #markdown-urgent-tasks