### PR TITLE
refactor: ビルド出力ディレクトリ整理 - frontend/astro/distに統一

### DIFF
--- a/.github/workflows/beaver.yml
+++ b/.github/workflows/beaver.yml
@@ -281,17 +281,17 @@ jobs:
           cd ../..
           
           # Verify Astro build output
-          if [ -d "_site-astro" ]; then
+          if [ -d "frontend/astro/dist" ]; then
             echo "✅ Astro build successful"
-            echo "📁 Astro generated content in _site-astro/"
-            ls -la _site-astro/
+            echo "📁 Astro generated content in frontend/astro/dist/"
+            ls -la frontend/astro/dist/
             
             # Prepare output directory for GitHub Pages
             rm -rf _site
-            mv _site-astro _site
-            echo "🔧 Moved _site-astro to _site for GitHub Pages deployment"
+            cp -r frontend/astro/dist _site
+            echo "🔧 Copied frontend/astro/dist to _site for GitHub Pages deployment"
           else
-            echo "❌ No _site-astro directory found - Astro build may have failed"
+            echo "❌ No frontend/astro/dist directory found - Astro build may have failed"
             exit 1
           fi
             

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GIT_COMMIT=$(shell git rev-parse --short HEAD)
 LDFLAGS=-ldflags "-X main.version=$(VERSION) -X 'main.buildTime=$(BUILD_TIME)' -X main.gitCommit=$(GIT_COMMIT)"
 
 # Build Configuration
-ASTRO_OUTPUT_DIR=_site-astro
+ASTRO_OUTPUT_DIR=frontend/astro/dist
 FINAL_OUTPUT_DIR=_site
 NODE_VERSION=18
 SCRIPTS_DIR=./scripts
@@ -267,8 +267,8 @@ astro-deps:
 astro-build: astro-deps
 	@echo "🎨 Astroフロントエンドをビルド中..."
 	cd $(ASTRO_DIR) && npm run build
-	@if [ -d "$(ASTRO_OUTPUT_DIR)" ]; then \
-		echo "✅ Astroビルド成功: $(ASTRO_OUTPUT_DIR)"; \
+	@if [ -d "$(ASTRO_DIR)/dist" ]; then \
+		echo "✅ Astroビルド成功: $(ASTRO_DIR)/dist"; \
 	else \
 		echo "❌ Astroビルド失敗"; \
 		exit 1; \
@@ -292,15 +292,15 @@ astro-lint: astro-deps
 ## astro-validate: Validate Astro build output
 astro-validate: astro-build
 	@echo "🔍 Astroビルド検証中..."
-	@if [ ! -f "$(ASTRO_OUTPUT_DIR)/index.html" ]; then \
+	@if [ ! -f "$(ASTRO_DIR)/dist/index.html" ]; then \
 		echo "❌ index.htmlが生成されていません"; \
 		exit 1; \
 	fi
 	@echo "📊 Astroビルド出力統計:"
-	@find $(ASTRO_OUTPUT_DIR) -type f -name "*.html" | wc -l | sed 's/^/  HTMLファイル: /'
-	@find $(ASTRO_OUTPUT_DIR) -type f -name "*.css" | wc -l | sed 's/^/  CSSファイル: /'
-	@find $(ASTRO_OUTPUT_DIR) -type f -name "*.js" | wc -l | sed 's/^/  JSファイル: /'
-	@du -sh $(ASTRO_OUTPUT_DIR) | sed 's/^/  総サイズ: /'
+	@find $(ASTRO_DIR)/dist -type f -name "*.html" | wc -l | sed 's/^/  HTMLファイル: /'
+	@find $(ASTRO_DIR)/dist -type f -name "*.css" | wc -l | sed 's/^/  CSSファイル: /'
+	@find $(ASTRO_DIR)/dist -type f -name "*.js" | wc -l | sed 's/^/  JSファイル: /'
+	@du -sh $(ASTRO_DIR)/dist | sed 's/^/  総サイズ: /'
 	@echo "✅ Astroビルド検証完了"
 
 ## astro-quality: Run all Astro quality checks
@@ -317,9 +317,9 @@ integrated-build: build
 	$(BUILD_DIR)/$(BINARY_NAME) build --astro-export
 	@echo "✅ Go backend データ生成完了"
 	@$(MAKE) astro-build
-	@if [ -d "$(ASTRO_OUTPUT_DIR)" ]; then \
+	@if [ -d "$(ASTRO_DIR)/dist" ]; then \
 		rm -rf $(FINAL_OUTPUT_DIR); \
-		mv $(ASTRO_OUTPUT_DIR) $(FINAL_OUTPUT_DIR); \
+		cp -r $(ASTRO_DIR)/dist $(FINAL_OUTPUT_DIR); \
 		echo "✅ 統合ビルド完了: $(FINAL_OUTPUT_DIR)"; \
 	else \
 		echo "❌ 統合ビルド失敗"; \

--- a/frontend/astro/astro.config.mjs
+++ b/frontend/astro/astro.config.mjs
@@ -5,7 +5,7 @@ import tailwind from '@astrojs/tailwind';
 export default defineConfig({
   integrations: [react(), tailwind()],
   output: 'static',
-  outDir: '../../_site-astro',
+  outDir: './dist',
   publicDir: './public',
   base: process.env.NODE_ENV === 'production' ? '/beaver/' : '/',
   server: {

--- a/frontend/astro/package.json
+++ b/frontend/astro/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .astro,.js,.jsx",
     "lint:fix": "eslint . --ext .astro,.js,.jsx --fix",
     "typecheck": "astro check",
-    "clean": "rm -rf dist _site-astro",
+    "clean": "rm -rf dist",
     "test": "echo 'No tests specified' && exit 0"
   },
   "dependencies": {

--- a/scripts/build-integrated.sh
+++ b/scripts/build-integrated.sh
@@ -67,7 +67,6 @@ clean_build() {
     rm -rf "$PROJECT_ROOT"/*.md
     
     # Remove Astro build outputs
-    rm -rf "$ASTRO_DIR/_site-astro"
     rm -rf "$ASTRO_DIR/dist"
     rm -rf "$ASTRO_DIR/.astro"
     
@@ -171,8 +170,8 @@ build_astro_frontend() {
     fi
     
     # Check if output was created
-    if [ -d "../../_site-astro" ]; then
-        log_success "✅ Astro build completed -> _site-astro/"
+    if [ -d "dist" ]; then
+        log_success "✅ Astro build completed -> dist/"
     else
         log_error "Astro build output not found"
         return 1
@@ -201,9 +200,9 @@ compare_outputs() {
     echo ""
     
     # Astro output
-    if [ -d "$PROJECT_ROOT/_site-astro" ]; then
-        local astro_size=$(du -sh "$PROJECT_ROOT/_site-astro" | cut -f1)
-        local astro_files=$(find "$PROJECT_ROOT/_site-astro" -type f | wc -l)
+    if [ -d "$ASTRO_DIR/dist" ]; then
+        local astro_size=$(du -sh "$ASTRO_DIR/dist" | cut -f1)
+        local astro_files=$(find "$ASTRO_DIR/dist" -type f | wc -l)
         echo "🎨 Astro Frontend Build:"
         echo "   Size: $astro_size"
         echo "   Files: $astro_files"
@@ -245,9 +244,9 @@ build_integrated() {
     fi
     
     # Step 3: Ensure primary _site points to Astro output
-    if [ -d "$PROJECT_ROOT/_site-astro" ]; then
+    if [ -d "$ASTRO_DIR/dist" ]; then
         rm -rf "$PROJECT_ROOT/_site"
-        cp -r "$PROJECT_ROOT/_site-astro" "$PROJECT_ROOT/_site"
+        cp -r "$ASTRO_DIR/dist" "$PROJECT_ROOT/_site"
         log_success "✅ Primary _site now uses Astro output"
     fi
     


### PR DESCRIPTION
## 概要

ビルド出力ディレクトリを整理し、理解しやすい構造に変更しました。

## 変更内容

- **Astro設定**: `outDir` を `'./dist'` に変更（ローカルdist使用）
- **Makefile**: 全Astro関連パスを `frontend/astro/dist` に統一
- **GitHub Actions**: ビルド検証とデプロイパスを `frontend/astro/dist` に変更
- **build-integrated.sh**: スクリプト内パス参照を統一
- **package.json**: clean スクリプト更新

## 技術的改善

- **理解しやすい命名**: 分かりにくい `_site-astro` を廃止
- **統一されたパス管理**: 全設定ファイルで一貫したパス使用
- **ローカルビルド**: Astroプロジェクト内にビルド出力を配置

## テスト

- `make quality` 実行：全品質チェック通過
- 全ユニットテスト通過
- pre-commit フック通過

🤖 Generated with [Claude Code](https://claude.ai/code)