### PR TITLE
feat: メインブランチ以外からのデプロイを有効化

### DIFF
--- a/.github/workflows/beaver.yml
+++ b/.github/workflows/beaver.yml
@@ -28,8 +28,9 @@ on:
     types: [opened, edited, closed, reopened, labeled, unlabeled]
 
   # Push to main branch - for production deployment
+  # Push to test branches - for testing deployment
   push:
-    branches: [main]
+    branches: [main, 'test/**']
 
   # Scheduled updates
   schedule:
@@ -64,7 +65,7 @@ jobs:
   preflight:
     name: 🔍 Pre-flight Checks
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/test/') }}
     outputs:
       should_update: ${{ steps.check_conditions.outputs.should_update }}
       update_type: ${{ steps.check_conditions.outputs.update_type }}
@@ -150,7 +151,7 @@ jobs:
     name: 🚀 Beaver Self-Documentation (GitHub Pages)
     runs-on: ubuntu-latest
     needs: preflight
-    if: ${{ needs.preflight.outputs.should_update == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.preflight.outputs.should_update == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/test/')) }}
 
     environment:
       name: github-pages
@@ -413,7 +414,7 @@ jobs:
     name: 🧹 Self-Documentation Cleanup
     runs-on: ubuntu-latest
     needs: [beaver-self-documentation]
-    if: ${{ always() && (github.event_name == 'schedule' || github.event.inputs.force_rebuild == 'true') && github.ref == 'refs/heads/main' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event.inputs.force_rebuild == 'true') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/test/')) }}
 
     steps:
       - name: 📥 Checkout code
@@ -457,7 +458,7 @@ jobs:
   weekly-self-analysis:
     name: 📈 Weekly Self-Analysis
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'schedule' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/test/')) }}
 
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
## 概要

test/**ブランチからGitHub Pagesデプロイを可能にして、PRの事前テストを効率化します。

## 変更内容

- **pushトリガー**: main + test/**ブランチからのプッシュに対応
- **preflight条件**: test/で始まるブランチを許可
- **デプロイ条件**: すべてのjobでtest/**ブランチからの実行を有効化
- **機能制限なし**: mainブランチと同等のフル機能でテスト可能

## 効果

- **PRテスト**: GitHub Pagesでの事前確認が可能
- **安全性**: test/**パターンで制限、意図しないデプロイを防止
- **開発効率**: 本番前に実際のPages環境でテスト可能

## 対象ブランチ

- ✅ `main` - 本番デプロイ
- ✅ `test/**` - テストデプロイ（例: test/option1-banner-removal）
- ❌ 他のブランチ - デプロイ対象外

## 使用例

```bash
# テスト用ブランチ作成
git checkout -b test/new-feature

# 変更をプッシュすると自動デプロイ
git push -u origin test/new-feature
```

## テスト

- ワークフロー構文チェック済み
- 条件ロジック確認済み
- 安全性確保済み

🤖 Generated with [Claude Code](https://claude.ai/code)