### PR TITLE
fix: ESLintでdist以下の生成JSファイルワーニング修正

### DIFF
--- a/frontend/astro/.eslintignore
+++ b/frontend/astro/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+.astro/


### PR DESCRIPTION
## 概要

ESLintで大量のワーニングが出ていたdist以下の生成JSファイルを除外対象に設定

## 変更内容

- frontend/astro/.eslintignoreファイルを新規作成
- 以下のディレクトリを除外対象に追加：
  - `dist/` - Astroビルド生成ファイル
  - `node_modules/` - 依存関係
  - `.astro/` - Astro内部ファイル

## テスト

- `make quality`実行時の大量ワーニングが解決されることを確認
- ESLintがビルド成果物をスキップし、ソースコードのみをチェック

これにより開発環境でのコード品質チェックが高速化され、実際のソースコードの問題に集中できます。

Closes #467