### PR TITLE
fix: GitHub Actions workflow path correction after script refactor

### DIFF
--- a/scripts/core/ci-beaver.sh
+++ b/scripts/core/ci-beaver.sh
@@ -11,7 +11,7 @@ export LANG=C.UTF-8
 
 # Script configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 BEAVER_BIN="${PROJECT_ROOT}/bin/beaver"
 LOG_FILE="${PROJECT_ROOT}/.beaver/ci-beaver.log"
 


### PR DESCRIPTION
## 概要

最近のスクリプトリファクタ後に発生していたBeaver Self-Documentation Automation workflowの失敗を修正

## 問題

リファクタにより、scripts/core/ci-beaver.sh内のPROJECT_ROOT計算が間違っていました：

間違った計算:
PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

これによりBEAVER_BIN="${PROJECT_ROOT}/bin/beaver"が/home/runner/work/beaver/beaver/scripts/bin/beaverを指していた

## 修正内容

PROJECT_ROOT計算を正しく修正：

正しい計算:
PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"

これによりBEAVER_BIN="${PROJECT_ROOT}/bin/beaver"が/home/runner/work/beaver/beaver/bin/beaverを正しく指すようになる

## テスト

- スクリプト構造の確認
- パス計算ロジックの検証
- ワークフロー実行での動作確認

Closes #469