### PR TITLE
refactor: CategoryShortcuts件数表示削除 - UI改善

### DIFF
--- a/frontend/astro/src/components/CategoryShortcuts.tsx
+++ b/frontend/astro/src/components/CategoryShortcuts.tsx
@@ -162,9 +162,6 @@ const CategoryShortcuts: React.FC<CategoryShortcutsProps> = ({ issues, className
                   <div className="text-xs opacity-75 mb-2">{category.description}</div>
                   
                   <div className="flex justify-center space-x-2 text-xs">
-                    <span className="px-2 py-1 bg-white dark:bg-gray-800 rounded-full">
-                      {categoryIssues.length}件
-                    </span>
                     {open > 0 && (
                       <span className="px-2 py-1 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-full">
                         {open} Open


### PR DESCRIPTION
## 概要

CategoryShortcutsコンポーネントから総件数表示（「X件」）を削除し、よりクリーンなUIに改善しました。

## 変更内容

### UI改善
- カテゴリカード内の総件数表示（「X件」）を削除
- Open状態のIssueがある場合のみ「Open」バッジを表示する設計に統一
- 不要な情報を削減してユーザビリティ向上

### 対象ファイル
- `frontend/astro/src/components/CategoryShortcuts.tsx`

## Before / After

**Before:**
```
[🐛 Bugs]
バグレポートと修正
[5件] [2 Open]
```

**After:**
```
[🐛 Bugs]  
バグレポートと修正
[2 Open]
```

## 効果

1. **視覚的改善**: よりクリーンで洗練されたカテゴリショートカットUI
2. **情報の最適化**: 重要な情報（Open件数）のみに焦点を当てた設計
3. **ノイズ削減**: 視覚的ノイズの削減により、ユーザーが重要な情報に集中しやすい

## テスト

- `make quality` でコード品質チェック完了
- 全ユニットテストが正常に通過
- プリコミットフックによる品質チェックも完了

🤖 Generated with [Claude Code](https://claude.ai/code)