### PR TITLE
fix: Issue #482修正 - プロジェクト健全度計算エラー修正

### DIFF
--- a/frontend/astro/src/components/DeveloperDashboard.tsx
+++ b/frontend/astro/src/components/DeveloperDashboard.tsx
@@ -277,7 +277,7 @@ const DeveloperDashboard: React.FC<DeveloperDashboardProps> = ({
               
               <div className="text-center p-4 bg-gradient-to-br from-orange-50 to-orange-100 dark:from-orange-900/20 dark:to-orange-800/20 rounded-lg">
                 <div className="text-2xl font-bold text-orange-600 dark:text-orange-400">
-                  {Math.round((statistics.health_score || 0) * 100)}%
+                  {Math.round(statistics.health_score || 0)}%
                 </div>
                 <div className="text-sm text-orange-800 dark:text-orange-300">
                   プロジェクト健全度


### PR DESCRIPTION
## 概要

Issue #482で報告されたプロジェクト健全度の異常値（9241%）を修正

## 変更内容

- DeveloperDashboard.tsx の健全度表示で二重の100倍計算を修正
- `Math.round((statistics.health_score || 0) * 100)` → `Math.round(statistics.health_score || 0)`
- バックエンドで既に0-100%で計算済みのため、フロントエンドでの追加乗算は不要

## テスト

- `make quality` 実行済み - 全テスト成功
- TypeScript/React コンパイルエラーなし
- 健全度表示が正常範囲（0-100%）に修正

## 期待結果

- 健全度: 9241% → 93% の正常表示
- ダッシュボードの信頼性向上

Closes #482