### PR TITLE
fix: CategoryShortcuts Total件数表示削除 & バックエンド分類ロジック改善

### DIFF
--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -1,8 +1,8 @@
-name: 🦫 Beaver Self-Documentation Automation
+name: 📚 Documentation Deployment
 
-# GitHub Pages-focused automation for Beaver self-management
-# Meta-documentation: Beaver managing its own project development through automated knowledge capture
-# v1.0: GitHub Pages only deployment with incremental updates and comprehensive self-analysis
+# GitHub Pages deployment automation for Beaver documentation
+# Automated generation and deployment of project knowledge base
+# Converts GitHub Issues into structured, searchable documentation
 
 permissions:
   contents: read

--- a/cmd/beaver/astro.go
+++ b/cmd/beaver/astro.go
@@ -340,18 +340,18 @@ func categorizeIssue(issue models.Issue) string {
 		searchText += " " + strings.ToLower(label.Name)
 	}
 
-	// Priority-based categorization to match frontend CategoryShortcuts.tsx
+	// Priority-based categorization to match frontend CategoryShortcuts.tsx exactly
 	// Check categories in priority order (most specific first)
 	categoryPriority := []struct {
 		key     string
 		filters []string
 	}{
-		{"critical", []string{"critical", "urgent", "high", "important", "priority"}},
+		{"critical", []string{"critical", "urgent", "priority: critical", "priority: high", "important"}},
 		{"bug", []string{"bug", "error", "defect", "fix"}},
 		{"security", []string{"security", "vulnerability", "auth", "permission"}},
 		{"performance", []string{"performance", "speed", "optimization", "slow"}},
 		{"deploy", []string{"deploy", "deployment", "release", "ci/cd", "build"}},
-		{"test", []string{"test", "testing", "spec", "qa"}},
+		{"test", []string{"testing", "spec", "qa"}}, // Removed "test" as it's too generic
 		{"docs", []string{"docs", "documentation", "readme", "guide"}},
 		{"feature", []string{"feature", "enhancement", "new", "add"}},
 	}

--- a/frontend/astro/src/components/CategoryShortcuts.tsx
+++ b/frontend/astro/src/components/CategoryShortcuts.tsx
@@ -248,7 +248,7 @@ const CategoryShortcuts: React.FC<CategoryShortcutsProps> = ({ issues, className
       </div>
 
       {/* Quick Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
         <div className="text-center p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
           <div className="text-lg font-bold text-green-600 dark:text-green-400">
             {issues.filter(i => i.state === 'open').length}
@@ -284,12 +284,6 @@ const CategoryShortcuts: React.FC<CategoryShortcutsProps> = ({ issues, className
           <div className="text-sm text-gray-600 dark:text-gray-400">Feature Open</div>
         </div>
         
-        <div className="text-center p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
-          <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
-            {issues.length}
-          </div>
-          <div className="text-sm text-gray-600 dark:text-gray-400">Total Issues</div>
-        </div>
       </div>
 
       {/* Usage Instructions */}


### PR DESCRIPTION
## 概要

CategoryShortcutsコンポーネントの表示改善とバックエンド分類ロジックの修正を行いました。

## 変更内容

### フロントエンド修正
- **Total Issues 表示を削除**: ユーザー要求に基づきTotal件数カウントを完全削除
- **レイアウト調整**: Quick Statsグリッドを6列から5列に変更

### バックエンド修正  
- **分類ロジック改善**: `categorizeIssue()` 関数の精度向上
  - "priority"フィルタを"priority: critical", "priority: high"に限定
  - 汎用的すぎる"test"キーワードを除去
  - フロントエンドとの一貫性確保

### その他
- **ワークフローファイル名変更**: `beaver.yml` → `docs-deployment.yml` (Issue #490対応)

## テスト

- `make quality` 全項目パス
- 分類ロジック検証: Issue #490 "deploy", Issue #482/483 "critical" に正しく分類
- フロントエンド・バックエンド間の整合性確認

Closes #476