### PR TITLE
fix: GitHub Actions統合 - doc deployment + coverage dashboard統合デプロイ

### DIFF
--- a/.github/workflows/coverage-dashboard.yml
+++ b/.github/workflows/coverage-dashboard.yml
@@ -1,14 +1,22 @@
-name: Coverage Dashboard
+# DEPRECATED: Coverage Dashboard functionality has been integrated into docs-deployment.yml
+# This workflow is kept for reference but is disabled to prevent conflicts
+
+name: Coverage Dashboard (DEPRECATED)
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main ]
+  # Disable all triggers - functionality moved to docs-deployment.yml
+  workflow_dispatch:
+    inputs:
+      force_enable:
+        description: "Force enable deprecated workflow (not recommended)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   coverage-analysis:
     runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.force_enable == 'true' }}
     
     steps:
     - name: Checkout code

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -185,6 +185,45 @@ jobs:
         run: |
           echo "🧪 Running unit tests (fast, no external dependencies)"
           make test-unit
+
+      - name: 📊 Generate Coverage Data
+        run: |
+          echo "📊 Generating coverage data for dashboard..."
+          # Run tests with coverage profile
+          go test -v -coverprofile=coverage.out ./...
+          
+          # Install beaver for coverage analysis
+          go install ./cmd/beaver
+          
+          # Generate coverage dashboard files
+          if [ -f "coverage.out" ]; then
+            echo "✅ Coverage data generated"
+            
+            # Generate interactive HTML dashboard
+            beaver coverage report --input coverage.out --format html --output coverage-dashboard.html
+            
+            # Export for GitHub Pages integration
+            beaver coverage export --input coverage.out --format github-pages --output coverage-data.json
+            
+            # Export CI summary for validation
+            beaver coverage export --input coverage.out --format ci-summary --output coverage-summary.json
+            
+            echo "📊 Coverage dashboard files generated successfully"
+          else
+            echo "⚠️ No coverage data found, skipping coverage dashboard generation"
+          fi
+
+      - name: 📊 Coverage Quality Check
+        if: hashFiles('coverage-summary.json') != ''
+        run: |
+          echo "📊 Checking coverage quality..."
+          # Show coverage summary but don't fail build
+          beaver coverage validate --min-coverage 70 --fail-on-low=false || echo "::warning::Coverage below 70% threshold"
+          
+          # Display coverage summary
+          if [ -f "coverage-summary.json" ]; then
+            echo "::notice::Coverage analysis completed - dashboard will be deployed"
+          fi
           
       - name: ✅ Verify installation
         env:
@@ -289,6 +328,27 @@ jobs:
             rm -rf _site
             cp -r frontend/astro/dist _site
             echo "🔧 Copied frontend/astro/dist to _site for GitHub Pages deployment"
+            
+            # Integrate coverage dashboard into site
+            if [ -f "coverage-dashboard.html" ] && [ -f "coverage-data.json" ]; then
+              echo "📊 Integrating coverage dashboard into GitHub Pages..."
+              
+              # Create coverage subdirectory in site
+              mkdir -p _site/coverage
+              
+              # Copy coverage files to site
+              cp coverage-dashboard.html _site/coverage/index.html
+              cp coverage-data.json _site/coverage/coverage-data.json
+              
+              # Copy additional coverage files if they exist
+              [ -f "coverage-summary.json" ] && cp coverage-summary.json _site/coverage/
+              [ -f "coverage.out" ] && cp coverage.out _site/coverage/
+              
+              echo "✅ Coverage dashboard integrated at /coverage/"
+              echo "🌐 Dashboard will be available at: https://${{ github.repository_owner }}.github.io/beaver/coverage/"
+            else
+              echo "⚠️ Coverage dashboard files not found, skipping coverage integration"
+            fi
           else
             echo "❌ No frontend/astro/dist directory found - Astro build may have failed"
             exit 1
@@ -381,6 +441,9 @@ jobs:
             .beaver/
             *.md
             !README.md
+            coverage-*.html
+            coverage-*.json
+            coverage.out
           retention-days: 7
           if-no-files-found: warn
 


### PR DESCRIPTION
## 📊 概要

GitHub Actionsワークフローを統合し、Coverage Dashboardの権限エラーとデプロイ競合問題を解決。doc deploymentとcoverage dashboardを単一ワークフローに統合して安定性向上。

## 🚫 解決された問題

### Coverage Dashboard ワークフロー失敗
```
remote: Permission to nyasuto/beaver.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/nyasuto/beaver.git/': The requested URL returned error: 403
```

### 別々デプロイによる競合・不安定性
- Git conflicts during parallel deployment
- Resource contention during site generation  
- Inconsistent state management

## 🔧 変更内容

### 📚 docs-deployment.yml 拡張
- **カバレッジ生成ステップ追加:**
  - `go test -coverprofile=coverage.out` でデータ収集
  - Interactive HTML dashboard生成
  - GitHub Pages用JSON export
  - CI summary生成

- **GitHub Pages統合:**
  - `/coverage/` パスでダッシュボードデプロイ
  - `coverage-dashboard.html` → `_site/coverage/index.html`
  - `coverage-data.json` → `_site/coverage/coverage-data.json`

- **カバレッジ品質チェック:**
  - 警告表示（ビルド停止なし）
  - `--fail-on-low=false` で継続実行

### 🚫 coverage-dashboard.yml 廃止
- DEPRECATEDマーク追加
- 自動トリガー無効化（`workflow_dispatch`のみ）
- `force_enable`フラグでのみ実行可能

## 🌐 デプロイ先

- **Documentation:** `https://nyasuto.github.io/beaver/`  
- **Coverage Dashboard:** `https://nyasuto.github.io/beaver/coverage/`

## 📈 効果

✅ **安定性向上:**
- 単一ワークフローによる競合回避
- 同一権限・環境設定使用
- 同一デプロイタイミング

✅ **管理性向上:**
- ワークフロー数削減（5→4）
- 統合されたアーティファクト管理
- 一貫したエラーハンドリング

✅ **機能性維持:**
- 全Coverage Dashboard機能保持
- Interactive charts & reports
- Multiple export formats

## テスト

- ✅ `make quality` 全チェック合格
- ✅ Pre-commit hooks 実行成功
- ✅ Unit tests 全合格

🤖 Generated with [Claude Code](https://claude.ai/code)