### PR TITLE
docs: Claude Code運用ルール追加 - PRマージ禁止を明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,3 +189,48 @@ A deployment is considered successful only when:
 - Validate mobile responsiveness of dashboard
 
 **Important**: Never assume deployment success based on workflow completion alone. Always confirm the live site functionality.
+
+## 🚨 **Critical Development Rules**
+
+### **Claude Code Operational Restrictions**
+
+**ABSOLUTE PROHIBITIONS - These rules MUST be followed without exception:**
+
+1. **🚫 NEVER MERGE PULL REQUESTS**
+   - Claude Code is STRICTLY FORBIDDEN from merging any pull requests
+   - This includes using `gh pr merge`, `--auto`, `--admin`, or any merge commands
+   - Pull requests must be reviewed and merged by human developers only
+   - Violation of this rule is unacceptable under any circumstances
+
+2. **✅ PERMITTED ACTIONS**
+   - ✅ Create pull requests (`gh pr create`)
+   - ✅ Write, edit, and commit code changes
+   - ✅ Push branches to remote repository
+   - ✅ Analyze code and provide recommendations
+   - ✅ Run tests and quality checks
+   - ✅ Debug and troubleshoot issues
+
+3. **🔄 PROPER WORKFLOW**
+   ```bash
+   # ✅ Correct workflow:
+   git checkout -b feature/my-fix
+   # Make code changes
+   git add .
+   git commit -m "fix: description"
+   git push -u origin feature/my-fix
+   gh pr create --title "Fix: Description" --body "Details"
+   # ❌ STOP HERE - DO NOT MERGE
+   
+   # ❌ FORBIDDEN:
+   gh pr merge [PR_NUMBER]  # NEVER DO THIS
+   ```
+
+4. **📋 COMMUNICATION PROTOCOL**
+   - Always inform the user when a PR is created
+   - Explain what the PR contains and why it's needed
+   - Let the user decide when and how to merge
+   - If urgent fixes are needed, clearly state the urgency but still wait for human approval
+
+### **Enforcement**
+
+These rules are non-negotiable and must be followed in all circumstances. Any violation compromises the development workflow and repository integrity.


### PR DESCRIPTION
## 概要

Claude Codeの運用ルールをCLAUDE.mdに追加し、PRマージ禁止を明文化

## 追加内容

### 🚨 Critical Development Rules
- **絶対禁止**: Claude CodeによるPRマージ
- **許可される操作**: PR作成、コード編集、テスト実行など
- **適切なワークフロー**: フィーチャーブランチ作成からPR作成まで
- **通信プロトコル**: ユーザーへの適切な報告方法

## 目的

- 開発ワークフローの整合性を保護
- レポジトリの安全性を確保
- Claude Codeの運用範囲を明確化
- 人間によるレビュープロセスを保持

これにより今後のClaude Code運用が明確になります。