### PR TITLE
fix: CodecovのPRコメント投稿を無効化

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+# Codecov Configuration
+comment: false  # Disable PR comments
+
 coverage:
   ignore:
     # Astro component files - レイアウトとUIコンポーネントは無視


### PR DESCRIPTION
## 概要

CodecovがPRにコメントを自動投稿することを無効化しました。

## 変更内容

- `codecov.yml` に `comment: false` を追加
- PRへの自動カバレッジコメント投稿を抑制

## 効果

- PRのコメント欄がCodecovの自動投稿で溢れることを防止
- カバレッジレポートは引き続きCodecovダッシュボードで確認可能
- CI/CDでのカバレッジチェック機能は維持

## テスト

- ✅ 全TypeScriptエラーなし
- ✅ ESLint警告のみ（16件、既存のnon-null assertion）
- ✅ 全テスト通過（186 passed | 2 skipped）
- ✅ Pre-commit hooks完全通過

🤖 Generated with [Claude Code](https://claude.ai/code)