### PR TITLE
fix: CSS読み込み問題修正 - Tailwind baseStyles有効化

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   integrations: [
     react(),
     tailwind({
-      applyBaseStyles: false,
+      applyBaseStyles: true,
     }),
   ],
   output: 'static',


### PR DESCRIPTION
## 🚨 緊急修正

**デプロイサイトでCSSが全く効いていない問題を修正**

### 🔍 問題の原因
- `applyBaseStyles: false` により Tailwind CSS の基本スタイルが無効化されていた
- 結果として美しいダッシュボードUIが全く表示されず、基本的なHTMLのみの表示

### 🔧 修正内容
- `astro.config.mjs` で `applyBaseStyles: true` に変更
- Tailwind CSS の基本スタイルを有効化

### 📊 修正前後の比較
**Before**: 
- 白い背景に基本テキストのみ
- カードデザインなし
- グラデーションバナーなし
- レスポンシブレイアウト機能なし

**After (期待結果)**:
- 美しいグラデーションバナー
- ガラスモーフィズムカードデザイン
- 3カラムレスポンシブレイアウト
- 統計カードの色分け表示

### 🎯 影響範囲
- GitHub Pages デプロイ全体のスタイル適用
- 全コンポーネントのTailwind CSS適用
- レスポンシブデザイン機能

### ✅ テスト結果
- 186 tests passed
- TypeScript: 0 errors, 0 warnings
- ESLint: 29 warnings (既存問題)

**緊急度**: Critical
**優先度**: High

🤖 Generated with [Claude Code](https://claude.ai/code)