### PR TITLE
fix: バナーグラデーション表示問題の修正

### DIFF
--- a/src/components/navigation/BannerWithData.astro
+++ b/src/components/navigation/BannerWithData.astro
@@ -60,7 +60,10 @@ const { showActions = true, class: className = '' } = Astro.props;
 ---
 
 <!-- Enhanced Banner for Issue 48 -->
-<div class={`banner-gradient ${className}`}>
+<div 
+  class={className}
+  style="background: linear-gradient(to right, #2563eb, #9333ea, #4338ca);"
+>
   <div class="container mx-auto px-4 py-6">
     <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
       <!-- Repository Information -->


### PR DESCRIPTION
## 概要

バナーグラデーションが白い背景で表示される問題を修正しました。

## 変更内容

- **問題**: BannerWithDataコンポーネントでバナーグラデーションが白い背景で表示される
- **原因**: Tailwindの@apply banner-gradientクラスがGitHub Pages環境で正しく読み込まれない
- **解決策**: インラインスタイルでlinear-gradientを直接指定

## 技術的改善

- `class="banner-gradient"` から `style="background: linear-gradient(to right, #2563eb, #9333ea, #4338ca);"` に変更
- CSS変数の依存関係を排除し、確実にグラデーションが表示されるよう改善
- GitHub Pages環境でのCSS読み込み問題を回避

## テスト

- ローカルビルドでグラデーションが正しく生成されることを確認
- 生成されたHTMLにインラインスタイルが適用されていることを確認

Closes #issue_number

🤖 Generated with [Claude Code](https://claude.ai/code)