### PR TITLE
fix: GitHub Pages リンク修正 - resolveUrl関数使用

### DIFF
--- a/src/components/dashboard/RecentActivity.astro
+++ b/src/components/dashboard/RecentActivity.astro
@@ -8,6 +8,7 @@
 
 import { formatDistanceToNow } from 'date-fns';
 import { getStatsService } from '../../lib/services/StatsService';
+import { resolveUrl } from '../../lib/utils/url';
 
 // Get unified statistics using the StatsService
 const statsService = getStatsService();
@@ -113,7 +114,7 @@ const { class: className = '' } = Astro.props;
     <div class="flex items-center justify-between mb-4">
       <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Recent Issues</h3>
       <a
-        href="/issues"
+        href={resolveUrl('/issues')}
         class="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
       >
         View all →

--- a/src/components/navigation/BannerWithData.astro
+++ b/src/components/navigation/BannerWithData.astro
@@ -6,6 +6,7 @@
  */
 
 // import Banner from './Banner.astro';
+import { resolveUrl } from '../../lib/utils/url';
 
 // Fetch repository data from API
 const fetchRepoData = async () => {
@@ -86,10 +87,10 @@ const { showActions = true, class: className = '' } = Astro.props;
       {
         showActions && (
           <div class="flex items-center space-x-3">
-            <a href="/issues" class="banner-action-btn">
+            <a href={resolveUrl('/issues')} class="banner-action-btn">
               View Issues
             </a>
-            <a href="/analytics" class="banner-action-btn">
+            <a href={resolveUrl('/analytics')} class="banner-action-btn">
               Analytics
             </a>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,7 +52,7 @@ const breadcrumbItems = [{ name: 'Home', href: resolveUrl('/'), current: true, i
           <!-- Primary Action Buttons -->
           <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center items-center">
             <a
-              href="/issues"
+              href={resolveUrl('/issues')}
               class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200 min-w-[160px] justify-center"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -65,7 +65,7 @@ const breadcrumbItems = [{ name: 'Home', href: resolveUrl('/'), current: true, i
               Manage Issues
             </a>
             <a
-              href="/analytics"
+              href={resolveUrl('/analytics')}
               class="inline-flex items-center px-6 py-3 border border-gray-300 dark:border-gray-600 text-base font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200 min-w-[160px] justify-center"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## 概要

GitHub Pagesでのリンク問題を修正しました。issuesとanalyticsページへのリンクが正しく動作するようになります。

## 問題

https://nyasuto.github.io/beaver/ サイトで以下のリンクが動作しませんでした：
- "Manage Issues" → `/issues` (404エラー)
- "View Analytics" → `/analytics` (404エラー)

## 解決策

ハードコードされたリンクパスを `resolveUrl()` 関数使用に変更：
- `/issues` → `/beaver/issues`
- `/analytics` → `/beaver/analytics`

## 修正ファイル

- ✅ `src/pages/index.astro` - メインページのアクションボタン
- ✅ `src/components/dashboard/RecentActivity.astro` - "View all →" リンク
- ✅ `src/components/navigation/BannerWithData.astro` - バナーアクションボタン

## テスト

- ✅ Build成功確認
- ✅ 生成されたHTMLでリンクパス確認: `/beaver/issues`, `/beaver/analytics`
- ✅ Type checking パス
- ✅ All tests passing

## 追加情報

既存の `resolveUrl()` ユーティリティ関数を活用し、GitHub Pagesの base path (`/beaver`) を自動的に適用します。

🤖 Generated with [Claude Code](https://claude.ai/code)