### PR TITLE
fix: ホームページのヘッダーナビゲーション統一を修正

### DIFF
--- a/src/components/layouts/PageLayout.astro
+++ b/src/components/layouts/PageLayout.astro
@@ -137,7 +137,7 @@ const baseLayoutProps = Object.fromEntries(
 
   <main id="main-content" class={mainClasses}>
     {
-      breadcrumbs && breadcrumbs.length > 1 && (
+      breadcrumbs && breadcrumbs.length > 0 && (
         <div class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
           <div class={containerClass}>
             <Breadcrumb items={breadcrumbs} separator={breadcrumbSeparator} class="py-3" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
-import { PageLayout } from '../components/layouts';
-import PageHeader from '../components/ui/PageHeader.astro';
+import PageLayout from '../components/layouts/PageLayout.astro';
 import IssueStats from '../components/dashboard/IssueStats.astro';
 import RecentActivity from '../components/dashboard/RecentActivity.astro';
 // resolveUrl is needed for breadcrumb navigation
@@ -27,12 +26,6 @@ const breadcrumbItems = [{ name: 'Home', href: resolveUrl('/'), current: true, i
   class="page-background"
   breadcrumbs={breadcrumbItems}
 >
-  <PageHeader
-    title="Beaver Astro Edition"
-    description="AI-first knowledge management system that transforms GitHub development activities into structured, persistent knowledge bases"
-    icon="🦫"
-  />
-
   <!-- Main Content -->
   <div class="min-h-screen">
     <!-- Hero Section -->


### PR DESCRIPTION
## 概要

各ページのデザイン統一作業の最終修正として、ホームページのヘッダーナビゲーション表示を他のページと統一します。

## 変更内容

### 修正したファイル

1. **`src/pages/index.astro`**
   - ❌ 間違った import: `import { PageLayout } from '../components/layouts';`
   - ✅ 正しい import: `import PageLayout from '../components/layouts/PageLayout.astro';`
   - 重複した PageHeader コンポーネントの削除

2. **`src/components/layouts/PageLayout.astro`**
   - breadcrumbs の表示条件を修正: `breadcrumbs.length > 1` → `breadcrumbs.length > 0`
   - ホームページでも breadcrumb が表示されるように修正

### 問題の詳細

- **根本原因**: 間違った import によって PageLayout コンポーネントが正しく読み込まれず、HTML に生の `<PageLayout>` タグが残っていた
- **影響**: ホームページのみヘッダーナビゲーションが表示されず、他のページと異なるデザインになっていた

## テスト

- ✅ ローカルビルドでHTMLが正しく生成されることを確認
- ✅ ヘッダーナビゲーションが適切に表示されることを確認
- ✅ breadcrumb が正しく表示されることを確認
- ✅ 全ての品質チェックが通過

## 技術的詳細

この修正により、以下の設計システム統一が完了しました：

1. **レイアウト統一**: 全ページで PageLayout 使用
2. **ヘッダー統一**: 統一されたナビゲーション表示
3. **Breadcrumb統一**: 一貫した階層表示
4. **スタイル統一**: 統一された背景色とスペーシング

🤖 Generated with [Claude Code](https://claude.ai/code)