### PR TITLE
fix: ブレッドクラムの上下余白を調整

### DIFF
--- a/src/components/dashboard/StatCard.astro
+++ b/src/components/dashboard/StatCard.astro
@@ -62,7 +62,13 @@ const trendColors = {
       <div class="min-w-0 flex-1">
         <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">{title}</h3>
         <p class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mt-1">{value}</p>
-        {description && <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-300 mt-1 truncate">{description}</p>}
+        {
+          description && (
+            <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-300 mt-1 truncate">
+              {description}
+            </p>
+          )
+        }
       </div>
     </div>
 
@@ -71,7 +77,9 @@ const trendColors = {
         <div class="flex items-center space-x-1 ml-2 flex-shrink-0">
           <span class="text-sm">{trendIcons[trend.direction]}</span>
           <span class={`text-sm font-medium ${trendColors[trend.direction]}`}>{trend.value}</span>
-          <span class="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">{trend.period}</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">
+            {trend.period}
+          </span>
         </div>
       )
     }

--- a/src/components/layouts/PageLayout.astro
+++ b/src/components/layouts/PageLayout.astro
@@ -140,7 +140,7 @@ const baseLayoutProps = Object.fromEntries(
       breadcrumbs && breadcrumbs.length > 0 && (
         <div class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
           <div class="container mx-auto max-w-full px-4 sm:px-6 lg:px-8">
-            <Breadcrumb items={breadcrumbs} separator={breadcrumbSeparator} class="py-2" />
+            <Breadcrumb items={breadcrumbs} separator={breadcrumbSeparator} class="py-2 px-2" />
           </div>
         </div>
       )

--- a/src/components/layouts/PageLayout.astro
+++ b/src/components/layouts/PageLayout.astro
@@ -139,8 +139,8 @@ const baseLayoutProps = Object.fromEntries(
     {
       breadcrumbs && breadcrumbs.length > 0 && (
         <div class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
-          <div class={containerClass}>
-            <Breadcrumb items={breadcrumbs} separator={breadcrumbSeparator} class="py-3" />
+          <div class="container mx-auto max-w-full px-4 sm:px-6 lg:px-8">
+            <Breadcrumb items={breadcrumbs} separator={breadcrumbSeparator} class="py-2" />
           </div>
         </div>
       )

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,21 +33,32 @@ const breadcrumbItems = [{ name: 'Home', href: resolveUrl('/'), current: true, i
       <div class="max-w-4xl mx-auto">
         <div class="text-center space-y-6 sm:space-y-8">
           <div class="space-y-4">
-            <h1 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl lg:text-5xl leading-tight">
+            <h1
+              class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl lg:text-5xl leading-tight"
+            >
               Welcome to Your Dashboard
             </h1>
-            <p class="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto leading-relaxed">
+            <p
+              class="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto leading-relaxed"
+            >
               Track project health and manage issues efficiently.
             </p>
           </div>
 
           <!-- Primary Action Buttons -->
-          <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center max-w-md mx-auto">
+          <div
+            class="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center max-w-md mx-auto"
+          >
             <a
               href={resolveUrl('/issues')}
               class="w-full sm:w-auto btn btn-primary px-6 py-3 text-base font-medium rounded-lg shadow-sm min-h-[48px] min-w-[160px] justify-center"
             >
-              <svg class="w-5 h-5 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg
+                class="w-5 h-5 mr-2 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -60,7 +71,12 @@ const breadcrumbItems = [{ name: 'Home', href: resolveUrl('/'), current: true, i
               href={resolveUrl('/analytics')}
               class="w-full sm:w-auto btn btn-outline px-6 py-3 text-base font-medium rounded-lg shadow-sm min-h-[48px] min-w-[160px] justify-center"
             >
-              <svg class="w-5 h-5 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg
+                class="w-5 h-5 mr-2 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"


### PR DESCRIPTION
## Summary
ブレッドクラムの上下余白が大きすぎる問題を修正しました。

## 問題
- ブレッドクラムで `py-3` クラスと `paddingClasses` の重複適用
- 結果として上下に過度な余白が発生し、視覚的に不自然

## 修正内容

### 📏 スペーシングの最適化
- ブレッドクラムの padding を `py-3` → `py-2` に変更
- より自然な視覚的バランスを実現

### 🏗️ コンテナ構造の改善  
- ブレッドクラム専用のコンテナクラスを使用
- `containerClass` の重複による余白の蓄積を回避

### 🎨 視覚的改善
- 適切な上下余白でより自然な見た目に調整
- 全体的なページレイアウトとの調和を向上

## Test plan
- [x] ビルドが正常に完了することを確認
- [x] 全テストが通過することを確認 (469 passed, 2 skipped)
- [x] TypeScript型チェックが通過することを確認
- [x] Lintingが通過することを確認
- [x] ブレッドクラムの視覚的な余白が適切になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)