### PR TITLE
fix: ホームページからブレッドクラムナビゲーションを削除

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,6 @@ const description = 'GitHub Issuesを永続的な知識ベースに変換';
               GitHub Issuesを永続的な知識ベースに変換
             </p>
           </div>
-
         </div>
       </div>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,14 +2,9 @@
 import PageLayout from '../components/layouts/PageLayout.astro';
 import IssueStats from '../components/dashboard/IssueStats.astro';
 import RecentActivity from '../components/dashboard/RecentActivity.astro';
-// resolveUrl is needed for breadcrumb navigation
-import { resolveUrl } from '../lib/utils/url';
 
 const title = '🦫 Beaver AI知識ダム';
 const description = 'GitHub Issuesを永続的な知識ベースに変換';
-
-// Breadcrumb items for home page
-const breadcrumbItems = [{ name: 'ホーム', href: resolveUrl('/'), current: true, icon: '🏠' }];
 ---
 
 <PageLayout
@@ -23,7 +18,6 @@ const breadcrumbItems = [{ name: 'ホーム', href: resolveUrl('/'), current: tr
   maxWidth="7xl"
   padding="lg"
   class="page-background"
-  breadcrumbs={breadcrumbItems}
 >
   <!-- Main Content -->
   <div class="min-h-screen">


### PR DESCRIPTION
## 概要

サイト構成が小規模なため、ホームページからブレッドクラムナビゲーションを削除し、よりクリーンなレイアウトを実現します。

## 変更内容

### 🧹 ナビゲーション整理
- ホームページからブレッドクラムナビゲーションを削除
- 未使用の`resolveUrl`インポートも削除
- ブレッドクラム関連のコードを完全に除去

### 🎨 UI改善効果
- よりシンプルでクリーンなレイアウト
- ヘッダーナビゲーションで十分なサイト規模
- 不要な視覚的ノイズを除去

### 📋 既存機能維持
- 日本語ローカライゼーション: 「🦫 Beaver AI知識ダム」
- 青紫グラデーションタイトル
- text-shadowビーバーアイコン
- レスポンシブデザイン

## テスト

- ✅ 品質チェック（lint、format、type-check）すべて通過
- ✅ 全テストケース通過（1611 tests passed）
- ✅ ナビゲーション機能の動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)