### PR TITLE
fix: Issue一覧ページでPRを除外しopenのみをデフォルト表示

### DIFF
--- a/src/lib/data/github.ts
+++ b/src/lib/data/github.ts
@@ -104,33 +104,43 @@ export function getStaticIssueById(issueNumber: number): GitHubIssue | undefined
 }
 
 /**
- * オープンな Issue のみを取得
+ * Pull Request を除外して Issue のみを取得
+ *
+ * @returns Pull Request を除外した Issue データ配列
+ */
+export function getIssuesOnly(): GitHubIssue[] {
+  const issues = getStaticIssues();
+  return issues.filter(issue => !issue.pull_request);
+}
+
+/**
+ * オープンな Issue のみを取得（Pull Request を除外）
  *
  * @returns オープンな Issue データ配列
  */
 export function getOpenIssues(): GitHubIssue[] {
-  const issues = getStaticIssues();
+  const issues = getIssuesOnly();
   return issues.filter(issue => issue.state === 'open');
 }
 
 /**
- * クローズされた Issue のみを取得
+ * クローズされた Issue のみを取得（Pull Request を除外）
  *
  * @returns クローズされた Issue データ配列
  */
 export function getClosedIssues(): GitHubIssue[] {
-  const issues = getStaticIssues();
+  const issues = getIssuesOnly();
   return issues.filter(issue => issue.state === 'closed');
 }
 
 /**
- * 特定のラベルを持つ Issue を取得
+ * 特定のラベルを持つ Issue を取得（Pull Request を除外）
  *
  * @param labelName ラベル名
  * @returns 指定されたラベルを持つ Issue データ配列
  */
 export function getIssuesByLabel(labelName: string): GitHubIssue[] {
-  const issues = getStaticIssues();
+  const issues = getIssuesOnly();
   return issues.filter(issue => issue.labels.some(label => label.name === labelName));
 }
 
@@ -236,4 +246,14 @@ export function getIssuesWithFallback(): GitHubIssue[] {
     console.warn('静的データの読み込みに失敗しました。フォールバックデータを使用します:', error);
     return getFallbackIssues();
   }
+}
+
+/**
+ * Pull Request を除外した Issue のみを安全に取得（フォールバック付き）
+ *
+ * @returns Pull Request を除外した Issue データ配列
+ */
+export function getIssuesOnlyWithFallback(): GitHubIssue[] {
+  const issues = getIssuesWithFallback();
+  return issues.filter(issue => !issue.pull_request);
 }

--- a/src/pages/issues/index.astro
+++ b/src/pages/issues/index.astro
@@ -9,7 +9,7 @@
 import PageLayout from '../../components/layouts/PageLayout.astro';
 import PageHeader from '../../components/ui/PageHeader.astro';
 import {
-  getIssuesWithFallback,
+  getIssuesOnlyWithFallback,
   getStaticMetadata,
   hasStaticData,
   getLastUpdated,
@@ -20,8 +20,8 @@ import { getFilterOptions } from '../../lib/utils/search';
 const title = 'Issue';
 const description = 'AI搭載の洞察でGitHubのIssueを閲覧・分析';
 
-// 静的データの読み込み
-let issues = getIssuesWithFallback();
+// 静的データの読み込み（PRを除外したissueのみ）
+const allIssues = getIssuesOnlyWithFallback();
 let metadata = null;
 let lastUpdated = null;
 let isDataAvailable = hasStaticData();
@@ -30,11 +30,6 @@ try {
   if (isDataAvailable) {
     metadata = getStaticMetadata();
     lastUpdated = getLastUpdated();
-
-    // 最新の Issue を先頭に表示
-    issues = issues.sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-    );
   }
 } catch (error) {
   // eslint-disable-next-line no-console
@@ -42,8 +37,17 @@ try {
   isDataAvailable = false;
 }
 
+// 最新の Issue を先頭に表示
+const issues = allIssues.sort(
+  (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+);
+
+// デフォルトはopenのissueのみ表示
 const openIssues = issues.filter(issue => issue.state === 'open');
 const closedIssues = issues.filter(issue => issue.state === 'closed');
+
+// 表示用のissues（デフォルトはopenのみ）
+const displayIssues = openIssues;
 
 // ラベルの集計とカテゴリ別グループ化
 const labelCounts = issues.reduce(
@@ -116,9 +120,9 @@ const filterOptions = getFilterOptions(issues);
           <div>
             <label class="label">ステータス</label>
             <select class="input" id="status-filter">
-              <option value="all">すべて ({issues.length})</option>
-              <option value="open">オープン ({openIssues.length})</option>
+              <option value="open" selected>オープン ({openIssues.length})</option>
               <option value="closed">クローズ ({closedIssues.length})</option>
+              <option value="all">すべて ({issues.length})</option>
             </select>
           </div>
 
@@ -247,7 +251,7 @@ const filterOptions = getFilterOptions(issues);
           <div class="flex items-center gap-4">
             <h2 class="text-lg font-semibold text-heading">Issue一覧</h2>
             <div class="flex items-center gap-2 text-sm text-muted" id="search-results-info">
-              <span id="results-count">{issues.length} 件の Issue を表示中</span>
+              <span id="results-count">{displayIssues.length} 件の Issue を表示中</span>
               <span id="search-time" class="hidden"></span>
             </div>
           </div>
@@ -276,7 +280,7 @@ const filterOptions = getFilterOptions(issues);
 
         <div class="space-y-4" id="issues-container">
           {
-            issues.length === 0 && (
+            displayIssues.length === 0 && (
               <div class="text-center py-8">
                 <p class="text-muted">
                   {isDataAvailable
@@ -288,7 +292,7 @@ const filterOptions = getFilterOptions(issues);
           }
 
           {
-            issues.map(issue => (
+            displayIssues.map(issue => (
               <div
                 class="p-4 border rounded-md issue-card"
                 data-state={issue.state}
@@ -361,7 +365,7 @@ const filterOptions = getFilterOptions(issues);
         </div>
 
         <div class="mt-6 text-center" id="pagination-info">
-          <p class="text-muted text-sm" id="pagination-text">{issues.length} 件の Issue を表示中</p>
+          <p class="text-muted text-sm" id="pagination-text">{displayIssues.length} 件の Issue を表示中</p>
           <div class="mt-2 hidden" id="search-stats">
             <span class="text-xs text-muted" id="search-performance"></span>
           </div>
@@ -471,7 +475,9 @@ const filterOptions = getFilterOptions(issues);
 
     constructor() {
       this.allIssues = Array.from(document.querySelectorAll('.issue-card'));
+      this.currentFilters.state = 'open'; // デフォルトはopenのみ
       this.initializeEventListeners();
+      this.performSearch(); // 初期フィルタリング実行
     }
 
     private initializeEventListeners() {


### PR DESCRIPTION
## 概要

Issue一覧ページでPull Requestが表示される問題と、closedのissueが混在する問題を修正しました。

## 修正内容

### 🔧 Issue一覧ページの改善
- **Pull Requestを除外**: GitHub APIでPRもissueとして扱われるため、PR除外処理を追加
- **デフォルト表示をopenのみに変更**: 閉じられたissueは表示せず、openのissueのみを表示
- **フィルター初期値変更**: ステータスフィルターのデフォルトを"open"に設定

### 🗂️ データ取得関数の拡張
- `getIssuesOnly()`: PR除外処理を追加
- `getIssuesOnlyWithFallback()`: フォールバック付きPR除外処理を追加
- 既存の関数もPR除外対応に更新

### 📋 変更されたファイル
- `src/lib/data/github.ts`: PR除外処理とデータ取得関数の改善
- `src/pages/issues/index.astro`: デフォルト表示ロジックの変更

## 解決された問題

1. **Pull Requestがissue一覧に表示される問題**: GitHub APIではPRも`issues`として扱われるため除外処理を追加
2. **closedのissueが混在表示される問題**: デフォルトでopenのissueのみを表示

## 影響範囲

- Issue一覧ページ: よりクリーンな表示（openのissueのみ）
- GitHub Pages: 不要なPR項目の非表示
- ユーザー体験: 関連性の高いissueのみ表示

## テスト

- ✅ 全1742個のテストが通過
- ✅ TypeScript型チェック通過
- ✅ ESLint警告のみ（エラーなし）
- ✅ フォーマットチェック通過

## 公開サイト

https://nyasuto.github.io/beaver/issues/ でopenのissueのみが表示されることを確認できます。