### PR TITLE
fix: 分類エンジンで既存のpriority labelsを優先的に認識

### DIFF
--- a/src/lib/classification/__tests__/engine.test.ts
+++ b/src/lib/classification/__tests__/engine.test.ts
@@ -685,6 +685,51 @@ describe('IssueClassificationEngine', () => {
   });
 
   describe('Priority Estimation', () => {
+    it('should prioritize existing priority labels over classification rules', () => {
+      const highPriorityIssue = createMockIssue({
+        title: 'Regular feature request',
+        body: 'Just a normal feature request',
+        labels: [
+          {
+            id: 1,
+            name: 'priority: high',
+            color: 'orange',
+            default: false,
+            description: null,
+            node_id: 'MDU6TGFiZWwx',
+          },
+        ],
+      });
+
+      const classification = engine.classifyIssue(highPriorityIssue);
+
+      expect(classification.estimatedPriority).toBe('high');
+      expect(classification.classifications[0]?.reasons).toContain(
+        'Has priority label: "priority: high"'
+      );
+    });
+
+    it('should handle priority:critical labels', () => {
+      const criticalIssue = createMockIssue({
+        title: 'Some issue',
+        body: 'Some content',
+        labels: [
+          {
+            id: 1,
+            name: 'priority: critical',
+            color: 'red',
+            default: false,
+            description: null,
+            node_id: 'MDU6TGFiZWwx',
+          },
+        ],
+      });
+
+      const classification = engine.classifyIssue(criticalIssue);
+
+      expect(classification.estimatedPriority).toBe('critical');
+    });
+
     it('should estimate critical priority for security issues', () => {
       const securityIssue = createMockIssue({
         title: 'Security vulnerability found',

--- a/src/pages/issues/index.astro
+++ b/src/pages/issues/index.astro
@@ -365,7 +365,9 @@ const filterOptions = getFilterOptions(issues);
         </div>
 
         <div class="mt-6 text-center" id="pagination-info">
-          <p class="text-muted text-sm" id="pagination-text">{displayIssues.length} 件の Issue を表示中</p>
+          <p class="text-muted text-sm" id="pagination-text">
+            {displayIssues.length} 件の Issue を表示中
+          </p>
           <div class="mt-2 hidden" id="search-stats">
             <span class="text-xs text-muted" id="search-performance"></span>
           </div>


### PR DESCRIPTION
## 概要

Issue分類エンジンでGitHubの既存priority labelsを優先的に認識するよう修正。これにより、`priority: high`などのラベルが付いたIssueが正しく優先度高として分類され、おすすめタスクに表示されるようになります。

## 変更内容

- `estimatePriority`メソッドを完全に書き直し、既存のGitHubラベルを最優先で認識
- `priority: critical`, `priority: high`, `priority: medium`, `priority: low`ラベルの検出を実装
- 分類結果に優先度ラベル使用の理由を追加
- 包括的なテストケースを追加（既存ラベル優先度認識テスト）
- TypeScriptの型安全性を向上

## テスト

- 全48テストが成功
- 優先度ラベル認識の新しいテストケースを追加
- 既存の分類ルールとの組み合わせテストも実施

Closes #141