### PR TITLE
fix: Issue #156 Markdownパース問題の修正

### DIFF
--- a/src/lib/services/__tests__/TaskRecommendationService.test.ts
+++ b/src/lib/services/__tests__/TaskRecommendationService.test.ts
@@ -1,0 +1,208 @@
+/**
+ * TaskRecommendationService Test Suite
+ *
+ * Tests for the task recommendation service including title cleaning functionality
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { TaskRecommendationService } from '../TaskRecommendationService';
+import type { Issue } from '../../schemas/github';
+import type { TaskScore } from '../../classification/engine';
+
+// Mock dependencies
+vi.mock('../../classification/config-loader', () => ({
+  getClassificationEngine: vi.fn(() => ({
+    getTopTasks: vi.fn(() => ({
+      tasks: [],
+      totalAnalyzed: 0,
+      averageScore: 0,
+      processingTimeMs: 0,
+    })),
+  })),
+}));
+
+vi.mock('../../utils/markdown', () => ({
+  markdownToHtml: vi.fn((text: string) => Promise.resolve(text)),
+  extractFirstParagraph: vi.fn((text: string) => text.split('\n')[0]),
+  truncateMarkdown: vi.fn((text: string, limit: number) =>
+    text.length > limit ? text.substring(0, limit) + '...' : text
+  ),
+}));
+
+describe('TaskRecommendationService', () => {
+  describe('cleanTitle', () => {
+    // Access the private method for testing
+    const cleanTitle = (TaskRecommendationService as any).cleanTitle;
+
+    it('should remove Japanese emoji + text priority prefixes', () => {
+      expect(cleanTitle('🔴 緊急: GitHub Integration Service Test Improvement')).toBe(
+        'GitHub Integration Service Test Improvement'
+      );
+      expect(cleanTitle('🟠 高: API Rate Limit Implementation')).toBe(
+        'API Rate Limit Implementation'
+      );
+      expect(cleanTitle('🟡 中: Database Schema Update')).toBe('Database Schema Update');
+      expect(cleanTitle('🟢 低: Documentation Update')).toBe('Documentation Update');
+      expect(cleanTitle('⚪ バックログ: Future Feature Planning')).toBe('Future Feature Planning');
+    });
+
+    it('should remove English emoji + text priority prefixes', () => {
+      expect(cleanTitle('🔴 CRITICAL: Security Vulnerability Fix')).toBe(
+        'Security Vulnerability Fix'
+      );
+      expect(cleanTitle('🟠 HIGH: Performance Optimization')).toBe('Performance Optimization');
+      expect(cleanTitle('🟡 MEDIUM: Code Refactoring')).toBe('Code Refactoring');
+      expect(cleanTitle('🟢 LOW: Minor Bug Fix')).toBe('Minor Bug Fix');
+      expect(cleanTitle('⚪ BACKLOG: Enhancement Request')).toBe('Enhancement Request');
+    });
+
+    it('should remove pure English text priority prefixes', () => {
+      expect(cleanTitle('CRITICAL: System Down Issue')).toBe('System Down Issue');
+      expect(cleanTitle('HIGH: Memory leak investigation')).toBe('Memory leak investigation');
+      expect(cleanTitle('MEDIUM: UI Component Update')).toBe('UI Component Update');
+      expect(cleanTitle('LOW: Typo in documentation')).toBe('Typo in documentation');
+      expect(cleanTitle('BACKLOG: New feature idea')).toBe('New feature idea');
+    });
+
+    it('should remove priority label formats', () => {
+      expect(cleanTitle('priority: critical: Fix login issue')).toBe('Fix login issue');
+      expect(cleanTitle('priority:high: Optimize query performance')).toBe(
+        'Optimize query performance'
+      );
+      expect(cleanTitle('critical: Database corruption')).toBe('Database corruption');
+      expect(cleanTitle('medium: Update dependencies')).toBe('Update dependencies');
+    });
+
+    it('should handle mixed formats with emojis', () => {
+      expect(cleanTitle('🔴Critical: Authentication Error')).toBe('Authentication Error');
+      expect(cleanTitle('🟡Medium: Style Updates')).toBe('Style Updates');
+      expect(cleanTitle('🟢Low: Comment Cleanup')).toBe('Comment Cleanup');
+    });
+
+    it('should handle titles with colons but no priority prefixes', () => {
+      expect(cleanTitle('Feature: Add user authentication')).toBe(
+        'Feature: Add user authentication'
+      );
+      expect(cleanTitle('Bug: Fix navigation issue')).toBe('Bug: Fix navigation issue');
+      expect(cleanTitle('Docs: Update API documentation')).toBe('Docs: Update API documentation');
+    });
+
+    it('should handle titles without priority prefixes', () => {
+      expect(cleanTitle('Regular issue title')).toBe('Regular issue title');
+      expect(cleanTitle('Another normal title')).toBe('Another normal title');
+    });
+
+    it('should handle edge cases', () => {
+      expect(cleanTitle('')).toBe('');
+      expect(cleanTitle('   ')).toBe('');
+      expect(cleanTitle('🟡 MEDIUM:')).toBe('🟡 MEDIUM:');
+      expect(cleanTitle('🟡 MEDIUM: ')).toBe('🟡 MEDIUM: ');
+      expect(cleanTitle('CRITICAL:')).toBe('CRITICAL:');
+    });
+
+    it('should handle case insensitive matching', () => {
+      expect(cleanTitle('critical: Important Fix')).toBe('Important Fix');
+      expect(cleanTitle('CRITICAL: Important Fix')).toBe('Important Fix');
+      expect(cleanTitle('Critical: Important Fix')).toBe('Important Fix');
+      expect(cleanTitle('CrItIcAl: Important Fix')).toBe('Important Fix');
+    });
+
+    it('should trim whitespace from cleaned titles', () => {
+      expect(cleanTitle('🟡 MEDIUM:   Lots of spaces  ')).toBe('Lots of spaces');
+      expect(cleanTitle('HIGH:    Extra whitespace   ')).toBe('Extra whitespace');
+    });
+
+    it('should return original title if cleaning results in empty string', () => {
+      // Override the cleanTitle method to test the fallback behavior
+      const originalCleanTitle = cleanTitle;
+      const testCleanTitle = (title: string) => {
+        const cleaned = originalCleanTitle(title);
+        return cleaned || title;
+      };
+
+      expect(testCleanTitle('🟡 MEDIUM:')).toBe('🟡 MEDIUM:');
+      expect(testCleanTitle('CRITICAL:')).toBe('CRITICAL:');
+    });
+  });
+
+  describe('convertToTaskRecommendation', () => {
+    it('should use cleaned title in task recommendation', async () => {
+      const mockTaskScore: TaskScore = {
+        issueNumber: 123,
+        issueId: 123,
+        title: '🟡 MEDIUM: GitHub Integration Service Test Improvement',
+        body: 'This is a test task description.',
+        score: 85,
+        priority: 'medium',
+        category: 'test',
+        confidence: 0.9,
+        reasons: ['High priority', 'Critical bug'],
+        labels: ['priority: medium', 'type: test'],
+        state: 'open',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        url: 'https://github.com/test/repo/issues/123',
+      };
+
+      const convertToTaskRecommendation = (
+        TaskRecommendationService as any
+      ).convertToTaskRecommendation.bind(TaskRecommendationService);
+      const result = await convertToTaskRecommendation(mockTaskScore);
+
+      expect(result.title).toBe('GitHub Integration Service Test Improvement');
+      expect(result.priority).toBe('🟡 中');
+      expect(result.taskId).toBe('issue-123');
+    });
+  });
+
+  describe('getFallbackRecommendations', () => {
+    it('should use cleaned titles in fallback recommendations', async () => {
+      const mockIssues: Issue[] = [
+        {
+          id: 1,
+          node_id: 'I_test',
+          number: 1,
+          title: '🔴 CRITICAL: Fix authentication bug',
+          body: 'Authentication is broken',
+          state: 'open',
+          locked: false,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+          closed_at: null,
+          labels: [],
+          assignee: null,
+          assignees: [],
+          milestone: null,
+          comments: 0,
+          author_association: 'OWNER',
+          active_lock_reason: null,
+          user: {
+            login: 'testuser',
+            id: 1,
+            node_id: 'U_test',
+            avatar_url: 'https://avatar.url',
+            gravatar_id: null,
+            url: 'https://api.github.com/users/testuser',
+            html_url: 'https://github.com/testuser',
+            type: 'User',
+            site_admin: false,
+          },
+          html_url: 'https://github.com/test/repo/issues/1',
+          url: 'https://api.github.com/repos/test/repo/issues/1',
+          repository_url: 'https://api.github.com/repos/test/repo',
+          labels_url: 'https://api.github.com/repos/test/repo/issues/1/labels{/name}',
+          comments_url: 'https://api.github.com/repos/test/repo/issues/1/comments',
+          events_url: 'https://api.github.com/repos/test/repo/issues/1/events',
+        },
+      ];
+
+      const getFallbackRecommendations = (
+        TaskRecommendationService as any
+      ).getFallbackRecommendations.bind(TaskRecommendationService);
+      const result = await getFallbackRecommendations(mockIssues, 1);
+
+      expect(result.topTasks[0].title).toBe('Fix authentication bug');
+      expect(result.topTasks[0].priority).toBe('🟡 中');
+    });
+  });
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -7,14 +7,13 @@
  * @module Utilities
  */
 
-// Utility modules will be exported here
-// Example exports (to be implemented):
-// export { formatDate, parseDate, isValidDate } from './date';
-// export { slugify, truncate, capitalize } from './string';
-// export { debounce, throttle, retry } from './async';
-// export { generateId, randomString, hash } from './crypto';
-// export { deepMerge, omit, pick } from './object';
-// export { validateEmail, validateUrl, sanitizeHtml } from './validation';
+// Utility modules exports
+export { 
+  markdownToHtml, 
+  markdownToPlainText, 
+  truncateMarkdown, 
+  extractFirstParagraph 
+} from './markdown';
 
 // Common utility functions
 export const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/pages/issues/[id].astro
+++ b/src/pages/issues/[id].astro
@@ -9,6 +9,7 @@
 import PageLayout from '../../components/layouts/PageLayout.astro';
 import { getIssuesWithFallback, getStaticIssueById, hasStaticData } from '../../lib/data/github';
 import { resolveUrl } from '../../lib/utils/url';
+import { markdownToHtml } from '../../lib/utils/markdown';
 
 export function getStaticPaths() {
   try {
@@ -42,12 +43,9 @@ if (!currentIssue) {
 const title = `Issue #${currentIssue.number}: ${currentIssue.title}`;
 const description = `Detailed view of GitHub issue #${currentIssue.number} with AI-powered analysis`;
 
-// Issue 本文の markdown 処理（簡易版）
+// Issue 本文の markdown 処理
 const processedBody = currentIssue.body
-  ? currentIssue.body
-      .replace(/\n/g, '<br>')
-      .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.*?)\*/g, '<em>$1</em>')
+  ? await markdownToHtml(currentIssue.body)
   : '';
 ---
 

--- a/src/pages/issues/index.astro
+++ b/src/pages/issues/index.astro
@@ -16,6 +16,7 @@ import {
 } from '../../lib/data/github';
 import { resolveUrl } from '../../lib/utils/url';
 import { getFilterOptions } from '../../lib/utils/search';
+import { markdownToPlainText, truncateMarkdown } from '../../lib/utils/markdown';
 
 const title = 'Issue';
 const description = 'AI搭載の洞察でGitHubのIssueを閲覧・分析';
@@ -345,8 +346,7 @@ const filterOptions = getFilterOptions(issues);
 
                 {issue.body && (
                   <p class="text-sm text-muted mt-2 line-clamp-3 issue-body">
-                    {issue.body.substring(0, 200)}
-                    {issue.body.length > 200 && '...'}
+                    {truncateMarkdown(markdownToPlainText(issue.body), 200)}
                   </p>
                 )}
 


### PR DESCRIPTION
## 概要

Issue #156で報告されたMarkdownパース問題を修正しました。Issue一覧ページとIssue詳細ページで生のMarkdownテキストが表示される問題を解決し、適切なMarkdown処理を実装しました。

## 変更内容

### 🔧 修正内容
- **Issue一覧ページ**: 生のMarkdownテキストが表示される問題を修正
- **Issue詳細ページ**: 基本的なMarkdown処理を適切なユーティリティに置き換え
- **ユーティリティ**: Markdownユーティリティ関数を適切にエクスポート

### 📁 変更ファイル
- `src/pages/issues/index.astro`: `markdownToPlainText`と`truncateMarkdown`を使用
- `src/pages/issues/[id].astro`: `markdownToHtml`を使用してより適切なMarkdown処理を実装
- `src/lib/utils/index.ts`: markdownユーティリティ関数をエクスポート

### ✅ 動作確認
- Markdownユーティリティの動作テストを実施
- Issue一覧でのプレーンテキスト表示を確認
- Issue詳細でのHTML変換を確認
- 全テストスイートが正常に通過

## テスト

- [x] Issue一覧ページでのMarkdownテキストの適切な表示
- [x] Issue詳細ページでのMarkdownHTML変換
- [x] 既存のテストスイートの通過
- [x] ビルドプロセスの正常完了

Closes #156