### PR TITLE
improve: おすすめタスクの説明文を100文字に短縮

### DIFF
--- a/src/lib/services/TaskRecommendationService.ts
+++ b/src/lib/services/TaskRecommendationService.ts
@@ -8,7 +8,7 @@
 import type { Issue } from '../schemas/github';
 import type { TaskScore } from '../classification/engine';
 import { getClassificationEngine } from '../classification/config-loader';
-import { markdownToHtml, extractFirstParagraph, truncateMarkdown } from '../utils/markdown';
+import { markdownToHtml, markdownToPlainText, truncateMarkdown } from '../utils/markdown';
 
 export interface TaskRecommendation {
   taskId: string;
@@ -114,9 +114,9 @@ export class TaskRecommendationService {
   private static generateTaskDescription(task: TaskScore): string {
     const body = task.body || '';
 
-    // Extract first paragraph and truncate if needed
-    const firstParagraph = extractFirstParagraph(body);
-    const truncated = truncateMarkdown(firstParagraph, 150);
+    // Convert to plain text and truncate to 100 characters
+    const plainText = markdownToPlainText(body);
+    const truncated = truncateMarkdown(plainText, 100);
 
     return truncated || 'No description available';
   }
@@ -257,7 +257,8 @@ export class TaskRecommendationService {
 
     const fallbackTasks: TaskRecommendation[] = await Promise.all(
       recentIssues.map(async (issue, index) => {
-        const description = truncateMarkdown(issue.body || '', 150);
+        const plainText = markdownToPlainText(issue.body || '');
+        const description = truncateMarkdown(plainText, 100);
         const descriptionHtml = await markdownToHtml(description);
 
         return {

--- a/src/lib/services/__tests__/TaskRecommendationService.test.ts
+++ b/src/lib/services/__tests__/TaskRecommendationService.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../classification/config-loader', () => ({
 
 vi.mock('../../utils/markdown', () => ({
   markdownToHtml: vi.fn((text: string) => Promise.resolve(text)),
-  extractFirstParagraph: vi.fn((text: string) => text.split('\n')[0]),
+  markdownToPlainText: vi.fn((text: string) => text.replace(/[*_`#]/g, '')),
   truncateMarkdown: vi.fn((text: string, limit: number) =>
     text.length > limit ? text.substring(0, limit) + '...' : text
   ),


### PR DESCRIPTION
## 概要

おすすめタスクの説明文表示を改善し、改行区切りではなく100文字で切り取るように変更しました。これにより、タスクカードでより読みやすい短い説明文が表示されます。

## 変更内容

### 🔧 修正内容
- **タスク説明文の長さ**: 150文字から100文字に短縮
- **表示方法**: 改行区切り（`extractFirstParagraph`）から文字数制限（`markdownToPlainText`）に変更
- **処理の統一**: `generateTaskDescription`と`getFallbackRecommendations`の両方で統一された処理を実装

### 📁 変更ファイル
- `src/lib/services/TaskRecommendationService.ts`: 
  - `generateTaskDescription`: `extractFirstParagraph` → `markdownToPlainText`使用
  - `getFallbackRecommendations`: 同様に100文字制限に統一
  - 不要な`extractFirstParagraph`インポートを削除
- `src/lib/services/__tests__/TaskRecommendationService.test.ts`: テストのモックを更新

### ✅ 改善効果
- より統一された短い説明文でタスクカードが読みやすくなる
- Markdownフォーマットを適切にプレーンテキストに変換
- UIの表示一貫性が向上

## テスト

- [x] 既存のテストスイートが正常に通過
- [x] TaskRecommendationServiceのテストが正常に動作
- [x] ビルドプロセスが正常に完了
- [x] 品質チェック（lint、format、type-check）が通過

## 技術的詳細

**変更前**:
```typescript
// 改行で区切って最初の段落を取得
const firstParagraph = extractFirstParagraph(body);
const truncated = truncateMarkdown(firstParagraph, 150);
```

**変更後**:
```typescript
// プレーンテキストに変換して100文字で切り取り
const plainText = markdownToPlainText(body);
const truncated = truncateMarkdown(plainText, 100);
```

この変更により、より簡潔で読みやすいタスク説明文が表示されるようになります。