### PR TITLE
fix: 最近の活動統計を削除してダッシュボードを改善

### DIFF
--- a/src/components/dashboard/IssueStats.astro
+++ b/src/components/dashboard/IssueStats.astro
@@ -24,7 +24,6 @@ const stats = statsResult.success ? statsResult.data : null;
 // Calculate derived metrics (preserve -1 for fallback data)
 const urgentIssues =
   stats && stats.meta.source !== 'fallback' ? stats.priority.critical + stats.priority.high : -1;
-const recentActivity = stats?.recentActivity.thisWeek ?? -1;
 
 // Export interface for type checking
 export interface Props {
@@ -34,7 +33,7 @@ export interface Props {
 const { class: className = '' } = Astro.props;
 ---
 
-<div class={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 ${className}`}>
+<div class={`grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 ${className}`}>
   <!-- オープンなIssue -->
   <StatCard
     title="オープンなIssue"
@@ -51,15 +50,6 @@ const { class: className = '' } = Astro.props;
     icon="🚨"
     description="クリティカル・高優先度"
     color="red"
-  />
-
-  <!-- 最近の活動 -->
-  <StatCard
-    title="最近の活動"
-    value={recentActivity}
-    icon="📈"
-    description="今週更新された"
-    color="blue"
   />
 </div>
 


### PR DESCRIPTION
## 問題

トップページの「最近の活動」統計が常に100という不正確な数値を表示していました。

## 修正内容

### 削除した機能
- 「最近の活動」StatCard（不正確な数値表示）
- 関連するrecentActivity変数の計算処理

### レイアウト調整
- グリッドレイアウトを3列から2列に変更
- レスポンシブデザインを維持（sm:grid-cols-2）
- より見やすい2列構成に最適化

### 残った機能
- ✅ オープンなIssue統計
- ✅ 緊急Issue統計（クリティカル・高優先度）
- ✅ フォールバックデータ表示
- ✅ データソース状態表示

## 視覚的変更

**Before (3列):**


**After (2列):**


## テスト

- ✅ 全品質チェック通過
- ✅ TypeScript型チェック通過
- ✅ 1486テスト通過
- ✅ レスポンシブデザイン維持

## 今後の改善

正確な「最近の活動」統計が必要な場合は、今後Phase 2のサービス層移行（#167）で改善予定です。

🤖 Generated with [Claude Code](https://claude.ai/code)