### PR TITLE
fix: タイトル周りの余白をコンパクトに最適化

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,18 +17,18 @@ const description = 'GitHub Issuesを永続的な知識ベースに変換';
   showFooter={true}
   showSearch={false}
   maxWidth="7xl"
-  padding="lg"
+  padding="md"
   class="page-background"
 >
   <!-- Main Content -->
   <div class="min-h-screen">
     <!-- Hero Section -->
-    <section class="py-8 sm:py-12 lg:py-16 px-4 sm:px-6 lg:px-8">
+    <section class="py-4 sm:py-6 lg:py-8 px-4 sm:px-6 lg:px-8">
       <div class="max-w-4xl mx-auto">
-        <div class="text-center space-y-6 sm:space-y-8">
-          <div class="space-y-4">
+        <div class="text-center space-y-4 sm:space-y-6">
+          <div class="space-y-3">
             <h1
-              class="text-6xl font-bold mb-6 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-tight"
+              class="text-6xl font-bold mb-3 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-tight"
             >
               <span class="beaver-icon">🦫</span> Beaver AI知識ダム
             </h1>
@@ -43,14 +43,14 @@ const description = 'GitHub Issuesを永続的な知識ベースに変換';
     </section>
 
     <!-- Statistics Section -->
-    <section class="py-8 sm:py-12 px-4 sm:px-6 lg:px-8">
+    <section class="py-4 sm:py-6 px-4 sm:px-6 lg:px-8">
       <div class="max-w-6xl mx-auto">
         <IssueStats />
       </div>
     </section>
 
     <!-- Main Dashboard Content -->
-    <section class="py-8 sm:py-12 px-4 sm:px-6 lg:px-8">
+    <section class="py-4 sm:py-6 px-4 sm:px-6 lg:px-8">
       <div class="max-w-6xl mx-auto">
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-2 gap-6 sm:gap-8">
           <!-- Top Tasks Recommendations -->


### PR DESCRIPTION
## 概要

Issue #173 UI改善: タイトル周りの余白をコンパクトにする の解決

過度な縦方向の余白を削減し、よりコンパクトでバランスの取れたレイアウトを実現しました。

## 変更内容

- **PageLayoutのパディング最適化**: `padding="lg"` から `padding="md"` に変更
- **ヒーローセクションの余白削減**: `py-8 sm:py-12 lg:py-16` から `py-4 sm:py-6 lg:py-8` に変更  
- **タイトル要素のマージン最適化**: `mb-6` から `mb-3` に削減
- **セクション間スペーシング調整**: `space-y-6 sm:space-y-8` から `space-y-4 sm:space-y-6` に変更
- **統計・ダッシュボードセクション**: 統一的に `py-4 sm:py-6` のパディングに調整

## テスト

- ✅ レスポンシブデザインが正常に動作することを確認
- ✅ すべてのブレークポイント (sm:, lg:) で適切な表示を確認
- ✅ 品質チェック通過 (lint, format, type-check, test)
- ✅ 1455個のテストすべてが成功

Closes #173