### PR TITLE
feat: ヘッダーロゴをビーバー絵文字からfavicon.pngに変更

### DIFF
--- a/src/components/navigation/Header.astro
+++ b/src/components/navigation/Header.astro
@@ -68,7 +68,7 @@ const headerClasses = [
       <div class="flex items-center">
         <a href={resolveUrl('/')} class="flex items-center space-x-2 group">
           <div
-            class="w-8 h-8 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-lg flex items-center justify-center group-hover:scale-105 transition-transform duration-200 p-1"
+            class="w-8 h-8 bg-white dark:bg-gray-100 rounded-lg flex items-center justify-center group-hover:scale-105 transition-transform duration-200 p-1 shadow-sm"
           >
             <img src={resolveUrl('/favicon.png')} alt="Beaver" class="w-6 h-6 object-contain" />
           </div>

--- a/src/components/navigation/Header.astro
+++ b/src/components/navigation/Header.astro
@@ -68,9 +68,9 @@ const headerClasses = [
       <div class="flex items-center">
         <a href={resolveUrl('/')} class="flex items-center space-x-2 group">
           <div
-            class="w-8 h-8 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-lg flex items-center justify-center group-hover:scale-105 transition-transform duration-200"
+            class="w-8 h-8 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-lg flex items-center justify-center group-hover:scale-105 transition-transform duration-200 p-1"
           >
-            <span class="text-white text-lg font-bold">🦫</span>
+            <img src={resolveUrl('/favicon.png')} alt="Beaver" class="w-6 h-6 object-contain" />
           </div>
           <span
             class="text-xl font-bold text-heading group-hover:text-primary-600 transition-colors"


### PR DESCRIPTION
## 概要

ヘッダーのロゴをビーバー絵文字（🦫）からfavicon.pngに変更しました。

## 変更内容

- **ロゴ変更**: ビーバー絵文字をfavicon.pngに置き換え
- **パス対応**: `resolveUrl`を使用してサブフォルダ配置に対応
- **レスポンシブ対応**: 画像サイズとパディングを最適化

## 技術的改善

### 変更されたファイル
- `src/components/navigation/Header.astro`
  - 絵文字スパンをimgタグに変更
  - `resolveUrl('/favicon.png')`でパス解決
  - `w-6 h-6 object-contain`でサイズ調整
  - `p-1`でパディング追加

### 改善ポイント
1. **サブフォルダ対応**: `resolveUrl`を使用してGitHub Pagesなどのサブフォルダ配置に対応
2. **レスポンシブ**: `object-contain`でアスペクト比を保持
3. **アクセシビリティ**: `alt="Beaver"`で適切な代替テキストを提供
4. **一貫性**: faviconと同じ画像を使用してブランドの統一感を向上

## 品質チェック結果

✅ **すべての品質チェックが正常に完了**
- Linting: 合格
- Format: 合格
- Type checking: 合格
- Unit tests: 1520 tests passed, 9 skipped

## 視覚的変更

- **Before**: 🦫 (ビーバー絵文字)
- **After**: \![favicon](favicon.png) (faviconと同じ画像)

🤖 Generated with [Claude Code](https://claude.ai/code)