### PR TITLE
fix: 未実装のモジュール分析ナビゲーションを削除

### DIFF
--- a/src/components/navigation/Header.astro
+++ b/src/components/navigation/Header.astro
@@ -30,7 +30,6 @@ const navItems = [
   { name: 'ホーム', href: resolveUrl('/'), icon: 'home', priority: 'primary' },
   { name: 'Issue', href: resolveUrl('/issues'), icon: 'bug', priority: 'primary' },
   { name: '品質分析', href: resolveUrl('/quality'), icon: 'quality', priority: 'secondary' },
-  { name: 'モジュール分析', href: resolveUrl('/modules'), icon: 'module', priority: 'secondary' },
   {
     name: 'ビーバーの事実',
     href: resolveUrl('/beaver-facts'),
@@ -166,16 +165,6 @@ const headerClasses = [
                           stroke-linejoin="round"
                           stroke-width="2"
                           d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                    )}
-                    {item.icon === 'module' && (
-                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
                         />
                       </svg>
                     )}
@@ -354,16 +343,6 @@ const headerClasses = [
                           stroke-linejoin="round"
                           stroke-width="2"
                           d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                    )}
-                    {item.icon === 'module' && (
-                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
                         />
                       </svg>
                     )}


### PR DESCRIPTION
## 概要

未実装のモジュール分析機能へのナビゲーションリンクを削除し、ユーザーが未実装機能にアクセスできないようにしました。

## 変更内容

### 削除した要素
- ヘッダーナビゲーションの「モジュール分析」リンク
- デスクトップメニューのモジュール分析項目
- モバイルメニューのモジュール分析項目  
- 関連するSVGアイコン（module icon）

### 影響範囲
- `src/components/navigation/Header.astro`
- デスクトップとモバイルの両方のナビゲーション

## 理由

モジュール分析機能はまだ実装されていないため、ユーザーがこの機能にアクセスしようとすると期待通りに動作しません。完全に実装されるまで、ナビゲーションからアクセスできないようにします。

## テスト

- 全1560テストが通過
- 品質チェック（linting、formatting、type-check）完了
- ナビゲーションが正常に動作することを確認

## 今後の対応

モジュール分析機能の実装が完了した際に、このナビゲーションリンクを再度追加する予定です。

🤖 Generated with [Claude Code](https://claude.ai/code)