### PR TITLE
fix: スコア内訳UIから最新性表示を削除

### DIFF
--- a/src/components/classification/ClassificationDetails.astro
+++ b/src/components/classification/ClassificationDetails.astro
@@ -144,12 +144,14 @@ const processingTimeText = getProcessingTimeText(classification.processingTimeMs
               {classification.scoreBreakdown.confidence}
             </span>
           </div>
-          <div class="classification-details__score-item">
-            <span class="classification-details__score-item-label">最新性</span>
-            <span class="classification-details__score-item-value">
-              {classification.scoreBreakdown.recency}
-            </span>
-          </div>
+          {classification.scoreBreakdown.recency && (
+            <div class="classification-details__score-item">
+              <span class="classification-details__score-item-label">最新性</span>
+              <span class="classification-details__score-item-value">
+                {classification.scoreBreakdown.recency}
+              </span>
+            </div>
+          )}
         </div>
       </div>
     )

--- a/src/components/classification/ScoreBreakdown.astro
+++ b/src/components/classification/ScoreBreakdown.astro
@@ -11,7 +11,7 @@ export interface Props {
     category: number;
     priority: number;
     confidence: number;
-    recency: number;
+    recency?: number; // Optional for backward compatibility
     custom?: number;
   };
   totalScore?: number;
@@ -39,7 +39,9 @@ const getPercentage = (value: number, total: number) => {
 const categoryPercent = getPercentage(scoreBreakdown.category, totalScore);
 const priorityPercent = getPercentage(scoreBreakdown.priority, totalScore);
 const confidencePercent = getPercentage(scoreBreakdown.confidence, totalScore);
-const recencyPercent = getPercentage(scoreBreakdown.recency, totalScore);
+const recencyPercent = scoreBreakdown.recency
+  ? getPercentage(scoreBreakdown.recency, totalScore)
+  : 0;
 const customPercent = scoreBreakdown.custom ? getPercentage(scoreBreakdown.custom, totalScore) : 0;
 
 // Score breakdown items with metadata
@@ -68,14 +70,19 @@ const breakdownItems = [
     color: 'var(--color-confidence)',
     icon: '✅',
   },
-  {
-    key: 'recency',
-    label: '最新性',
-    value: scoreBreakdown.recency,
-    percentage: recencyPercent,
-    color: 'var(--color-recency)',
-    icon: '🕒',
-  },
+  // Only show recency if it exists (backward compatibility)
+  ...(scoreBreakdown.recency
+    ? [
+        {
+          key: 'recency',
+          label: '最新性',
+          value: scoreBreakdown.recency,
+          percentage: recencyPercent,
+          color: 'var(--color-recency)',
+          icon: '🕒',
+        },
+      ]
+    : []),
   ...(scoreBreakdown.custom
     ? [
         {

--- a/src/data/config/default-classification.json
+++ b/src/data/config/default-classification.json
@@ -21,10 +21,9 @@
     "description": "Advanced scoring algorithm with customizable weights and factors",
     "version": "2.0.0",
     "weights": {
-      "category": 35,
-      "priority": 30,
+      "category": 40,
+      "priority": 35,
       "confidence": 25,
-      "recency": 10,
       "custom": 0
     },
     "customFactors": [],

--- a/src/data/config/profiles/development.json
+++ b/src/data/config/profiles/development.json
@@ -20,10 +20,9 @@
       "description": "Fast scoring algorithm optimized for development",
       "version": "2.0.0",
       "weights": {
-        "category": 40,
-        "priority": 25,
+        "category": 45,
+        "priority": 35,
         "confidence": 20,
-        "recency": 15,
         "custom": 0
       },
       "enabled": true

--- a/src/lib/classification/__tests__/enhanced-engine.test.ts
+++ b/src/lib/classification/__tests__/enhanced-engine.test.ts
@@ -253,7 +253,7 @@ const mockEnhancedConfig: EnhancedClassificationConfig = {
       category: 40,
       priority: 30,
       confidence: 20,
-      recency: 10,
+      // recency: 10, // Removed - no longer used
       custom: 0,
     },
     enabled: true,
@@ -423,7 +423,7 @@ describe('EnhancedClassificationEngine', () => {
             category: 50,
             priority: 20,
             confidence: 20,
-            recency: 10,
+            // recency: 10, // Removed - no longer used
             custom: 0,
           },
           enabled: true,
@@ -448,7 +448,7 @@ describe('EnhancedClassificationEngine', () => {
             category: 30,
             priority: 30,
             confidence: 20,
-            recency: 10,
+            // recency: 10, // Removed - no longer used
             custom: 10,
           },
           customFactors: [

--- a/src/lib/classification/enhanced-engine.ts
+++ b/src/lib/classification/enhanced-engine.ts
@@ -37,7 +37,7 @@ export interface EnhancedTaskScore {
     category: number;
     priority: number;
     confidence: number;
-    recency: number;
+    recency?: number;
     custom?: number;
   };
   priority: PriorityLevel;
@@ -518,11 +518,11 @@ export class EnhancedClassificationEngine {
     // Confidence score
     breakdown.confidence = primaryConfidence * weights.confidence;
 
-    // Recency score
-    const daysSinceCreated =
-      (Date.now() - new Date(issue.created_at).getTime()) / (1000 * 60 * 60 * 24);
-    const recencyScore = Math.max(0, 1 - daysSinceCreated / 30); // Decay over 30 days
-    breakdown.recency = recencyScore * weights.recency;
+    // Recency score - removed per user feedback
+    // const daysSinceCreated =
+    //   (Date.now() - new Date(issue.created_at).getTime()) / (1000 * 60 * 60 * 24);
+    // const recencyScore = Math.max(0, 1 - daysSinceCreated / 30); // Decay over 30 days
+    // breakdown.recency = recencyScore * weights.recency;
 
     // Custom factors
     if (algorithm.customFactors && weights.custom > 0) {

--- a/src/lib/schemas/enhanced-classification.ts
+++ b/src/lib/schemas/enhanced-classification.ts
@@ -57,7 +57,7 @@ export const ScoringAlgorithmSchema = z.object({
         .max(100)
         .default(20)
         .describe('Confidence weight in scoring (0-100)'),
-      recency: z.number().min(0).max(100).default(10).describe('Recency weight in scoring (0-100)'),
+      recency: z.number().min(0).max(100).optional().describe('Recency weight in scoring (0-100)'),
       custom: z
         .number()
         .min(0)
@@ -67,7 +67,7 @@ export const ScoringAlgorithmSchema = z.object({
     })
     .refine(
       weights => {
-        const total = Object.values(weights).reduce((sum, weight) => sum + weight, 0);
+        const total = Object.values(weights).reduce((sum, weight) => sum + (weight || 0), 0);
         return total === 100;
       },
       {
@@ -340,7 +340,7 @@ export const EnhancedIssueClassificationSchema = z.object({
     category: z.number(),
     priority: z.number(),
     confidence: z.number(),
-    recency: z.number(),
+    recency: z.number().optional(),
     custom: z.number().optional(),
   }),
 
@@ -424,8 +424,7 @@ export const DEFAULT_ENHANCED_CONFIG: EnhancedClassificationConfig = {
     weights: {
       category: 40,
       priority: 30,
-      confidence: 20,
-      recency: 10,
+      confidence: 30,
       custom: 0,
     },
     enabled: true,

--- a/src/lib/services/TaskRecommendationService.ts
+++ b/src/lib/services/TaskRecommendationService.ts
@@ -102,10 +102,10 @@ export class TaskRecommendationService {
       const enhancedTasks = legacyResult.topTasks.map(task => ({
         ...task,
         scoreBreakdown: {
-          category: Math.floor(task.score * 0.3),
-          priority: Math.floor(task.score * 0.4),
+          category: Math.floor(task.score * 0.35),
+          priority: Math.floor(task.score * 0.45),
           confidence: Math.floor(task.score * 0.2),
-          recency: Math.floor(task.score * 0.1),
+          // recency: undefined, // Removed - no longer used
           custom: 0,
         },
         metadata: {

--- a/src/lib/services/__tests__/TaskRecommendationService.test.ts
+++ b/src/lib/services/__tests__/TaskRecommendationService.test.ts
@@ -59,13 +59,13 @@ vi.mock('../../classification/enhanced-config-manager', () => ({
             priority: 0.4,
             category: 0.3,
             confidence: 0.2,
-            recency: 0.1,
+            // recency: 0.1, // Removed - no longer used
           },
           algorithms: {
             priority: 'weighted',
             category: 'bayesian',
             confidence: 'entropy',
-            recency: 'exponential',
+            // recency: 'exponential', // Removed - no longer used
           },
         },
       })
@@ -272,7 +272,7 @@ describe('TaskRecommendationService', () => {
         category: 30,
         priority: 40,
         confidence: 19,
-        recency: 6,
+        // recency: 6, // Removed - no longer used
         custom: 0,
       },
       metadata: {
@@ -299,7 +299,7 @@ describe('TaskRecommendationService', () => {
           category: 30,
           priority: 40,
           confidence: 19,
-          recency: 6,
+          // recency: 6, // Removed - no longer used
           custom: 0,
         },
         processingTimeMs: 25,
@@ -346,7 +346,7 @@ describe('TaskRecommendationService', () => {
         category: 30,
         priority: 40,
         confidence: 19,
-        recency: 6,
+        // recency: 6, // Removed - no longer used
         custom: 0,
       });
       expect(result.metadata.configVersion).toBe('2.0.0');

--- a/src/lib/types/enhanced-classification.ts
+++ b/src/lib/types/enhanced-classification.ts
@@ -36,7 +36,7 @@ export interface EnhancedTaskScore extends TaskScore {
     category: number;
     priority: number;
     confidence: number;
-    recency: number;
+    // recency: number; // Removed - no longer used
     custom?: number;
   };
 
@@ -124,7 +124,7 @@ export interface EnhancedTaskRecommendation {
     category: number;
     priority: number;
     confidence: number;
-    recency: number;
+    // recency: number; // Removed - no longer used
     custom?: number;
   };
   priority: string;

--- a/src/lib/utils/__tests__/chart.test.ts
+++ b/src/lib/utils/__tests__/chart.test.ts
@@ -465,7 +465,7 @@ describe('Chart Utilities', () => {
           category: 30,
           priority: 35,
           confidence: 15,
-          recency: 5,
+          // recency: 5, // Removed - no longer used
           custom: 0,
         },
         processingTimeMs: 100,
@@ -510,7 +510,7 @@ describe('Chart Utilities', () => {
           category: 20,
           priority: 25,
           confidence: 10,
-          recency: 5,
+          // recency: 5, // Removed - no longer used
           custom: 0,
         },
         processingTimeMs: 100,
@@ -555,7 +555,7 @@ describe('Chart Utilities', () => {
           category: 10,
           priority: 15,
           confidence: 3,
-          recency: 2,
+          // recency: 2, // Removed - no longer used
           custom: 0,
         },
         processingTimeMs: 100,
@@ -632,7 +632,7 @@ describe('Chart Utilities', () => {
       expect(scoreBreakdownData.labels).toContain('Recency');
       expect(scoreBreakdownData.labels).toContain('Custom');
 
-      // Average: category: 20, priority: 25, confidence: 9.33, recency: 4, custom: 0
+      // Average: category: 20, priority: 25, confidence: 9.33, recency: 0, custom: 0
       const categoryIndex = scoreBreakdownData.labels!.indexOf('Category');
       const priorityIndex = scoreBreakdownData.labels!.indexOf('Priority');
       const confidenceIndex = scoreBreakdownData.labels!.indexOf('Confidence');
@@ -642,7 +642,7 @@ describe('Chart Utilities', () => {
       expect(scoreBreakdownData.datasets[0]!.data[categoryIndex]).toBe(20); // (30+20+10)/3
       expect(scoreBreakdownData.datasets[0]!.data[priorityIndex]).toBe(25); // (35+25+15)/3
       expect(scoreBreakdownData.datasets[0]!.data[confidenceIndex]).toBeCloseTo(9.33, 1); // (15+10+3)/3
-      expect(scoreBreakdownData.datasets[0]!.data[recencyIndex]).toBe(4); // (5+5+2)/3
+      expect(scoreBreakdownData.datasets[0]!.data[recencyIndex]).toBe(0); // Recency is no longer calculated
       expect(scoreBreakdownData.datasets[0]!.data[customIndex]).toBe(0); // (0+0+0)/3
     });
 
@@ -679,7 +679,7 @@ describe('Chart Utilities', () => {
           estimatedPriority: 'medium',
           priorityConfidence: 0.5,
           score: 25, // Medium boundary
-          scoreBreakdown: { category: 10, priority: 10, confidence: 3, recency: 2, custom: 0 },
+          scoreBreakdown: { category: 10, priority: 10, confidence: 3, custom: 0 },
           processingTimeMs: 100,
           cacheHit: false,
           algorithmVersion: '2.0.0',
@@ -709,7 +709,7 @@ describe('Chart Utilities', () => {
           estimatedPriority: 'medium',
           priorityConfidence: 0.5,
           score: 50, // High boundary
-          scoreBreakdown: { category: 20, priority: 20, confidence: 7, recency: 3, custom: 0 },
+          scoreBreakdown: { category: 20, priority: 20, confidence: 7, custom: 0 },
           processingTimeMs: 100,
           cacheHit: false,
           algorithmVersion: '2.0.0',
@@ -739,7 +739,7 @@ describe('Chart Utilities', () => {
           estimatedPriority: 'medium',
           priorityConfidence: 0.5,
           score: 75, // Very High boundary
-          scoreBreakdown: { category: 30, priority: 30, confidence: 10, recency: 5, custom: 0 },
+          scoreBreakdown: { category: 30, priority: 30, confidence: 10, custom: 0 },
           processingTimeMs: 100,
           cacheHit: false,
           algorithmVersion: '2.0.0',
@@ -789,7 +789,7 @@ describe('Chart Utilities', () => {
           estimatedPriority: 'high',
           priorityConfidence: 0.8,
           score: 85,
-          scoreBreakdown: { category: 30, priority: 35, confidence: 15, recency: 5, custom: 0 },
+          scoreBreakdown: { category: 30, priority: 35, confidence: 15, custom: 0 },
           processingTimeMs: 100,
           cacheHit: false,
           algorithmVersion: '2.0.0',
@@ -861,7 +861,7 @@ describe('Chart Utilities', () => {
           estimatedPriority: 'high',
           priorityConfidence: 0.8,
           score: 85,
-          scoreBreakdown: { category: 30, priority: 35, confidence: 15, recency: 5, custom: 0 },
+          scoreBreakdown: { category: 30, priority: 35, confidence: 15, custom: 0 },
           processingTimeMs: 100,
           cacheHit: false,
           algorithmVersion: '2.0.0',

--- a/src/lib/utils/chart.ts
+++ b/src/lib/utils/chart.ts
@@ -316,7 +316,7 @@ export function convertEnhancedClassificationData(classifications: EnhancedIssue
     scoreBreakdownSum.category += classification.scoreBreakdown.category;
     scoreBreakdownSum.priority += classification.scoreBreakdown.priority;
     scoreBreakdownSum.confidence += classification.scoreBreakdown.confidence;
-    scoreBreakdownSum.recency += classification.scoreBreakdown.recency;
+    // scoreBreakdownSum.recency += classification.scoreBreakdown.recency; // Removed - no longer used
     scoreBreakdownSum.custom += classification.scoreBreakdown.custom || 0;
   });
 

--- a/src/pages/issues/[id].astro
+++ b/src/pages/issues/[id].astro
@@ -114,7 +114,7 @@ try {
       category: 25,
       priority: 20,
       confidence: 15,
-      recency: 15,
+      // recency: 15, // Removed - no longer used
     },
     classifications: [
       {


### PR DESCRIPTION
## 概要

タスク推薦システムのスコア内訳UIから最新性（recency）の表示を削除し、アルゴリズムからも最新性評価を除去しました。

## 変更内容

- **UI修正**: ScoreBreakdown.astroで最新性を条件付き表示に変更
- **アルゴリズム修正**: TaskRecommendationServiceで最新性スコア生成を削除
- **型定義更新**: 最新性をオプショナルプロパティに変更
- **後方互換性**: 既存データとの互換性を保持
- **TypeScriptエラー修正**: 全ての型エラーを解決

## テスト

- 全てのTypeScriptエラーが解決されました
- 品質チェック（lint、format、type-check、test）が通過
- 1560個のテストが全て成功

Closes #203