### PR TITLE
fix: スコア配分計算の修正とパーセンテージ表示の改善

### DIFF
--- a/src/components/classification/ScoreBreakdown.astro
+++ b/src/components/classification/ScoreBreakdown.astro
@@ -31,18 +31,18 @@ const {
   className = '',
 } = Astro.props;
 
-// Calculate percentages for each component
+// Calculate percentages for each component based on actual score, not totalScore
 const getPercentage = (value: number, total: number) => {
-  return Math.round((value / total) * 100);
+  return total > 0 ? Math.round((value / total) * 100) : 0;
 };
 
-const categoryPercent = getPercentage(scoreBreakdown.category, totalScore);
-const priorityPercent = getPercentage(scoreBreakdown.priority, totalScore);
+const categoryPercent = getPercentage(scoreBreakdown.category, score);
+const priorityPercent = getPercentage(scoreBreakdown.priority, score);
 // const confidencePercent = getPercentage(scoreBreakdown.confidence, totalScore); // Removed
 const recencyPercent = scoreBreakdown.recency
-  ? getPercentage(scoreBreakdown.recency, totalScore)
+  ? getPercentage(scoreBreakdown.recency, score)
   : 0;
-const customPercent = scoreBreakdown.custom ? getPercentage(scoreBreakdown.custom, totalScore) : 0;
+const customPercent = scoreBreakdown.custom ? getPercentage(scoreBreakdown.custom, score) : 0;
 
 // Score breakdown items with metadata
 const breakdownItems = [

--- a/src/lib/services/TaskRecommendationService.ts
+++ b/src/lib/services/TaskRecommendationService.ts
@@ -102,9 +102,8 @@ export class TaskRecommendationService {
       const enhancedTasks = legacyResult.topTasks.map(task => ({
         ...task,
         scoreBreakdown: {
-          category: Math.floor(task.score * 0.5),
-          priority: Math.floor(task.score * 0.5),
-          // confidence: Math.floor(task.score * 0.2), // Removed - no longer part of scoreBreakdown
+          category: Math.ceil(task.score * 0.5),
+          priority: task.score - Math.ceil(task.score * 0.5),  // Ensure total equals task.score
           custom: 0,
         },
         metadata: {


### PR DESCRIPTION
## 概要

スコア合計不一致エラーを修正し、パーセンテージ表示を正確に計算するよう改善

## 変更内容

- **TaskRecommendationService**: スコア配分計算で合計値が一致するよう修正
- **ScoreBreakdown**: パーセンテージ計算を実際のスコアベースに変更
- カテゴリ/優先度の配分が正確に100%になるよう調整

## 技術的改善

1. **スコア配分の修正**:
   - `priority: task.score - Math.ceil(task.score * 0.5)` で残りのスコアを確実に割り当て
   - スコア合計が元の値と一致することを保証

2. **パーセンテージ計算の改善**:
   - `totalScore = 100` ではなく実際の `score` をベースに計算
   - 35% + 35% = 70% のような意味不明な表示を修正

## テスト

- 品質チェックが通っている
- ビルドが成功している
- スコア配分エラーが解決されている

🤖 Generated with [Claude Code](https://claude.ai/code)