### PR TITLE
feat: おすすめタスクに実際のIssue番号表示とクリック機能を追加

### DIFF
--- a/src/components/dashboard/TopTasks.astro
+++ b/src/components/dashboard/TopTasks.astro
@@ -96,14 +96,17 @@ function getPriorityColor(priority: string): string {
           </p>
         </div>
       ) : (
-        topTasks.map((task, index) => (
+        topTasks.map(task => (
           <div class="border rounded-lg p-4 hover:shadow-md transition-shadow duration-200">
             <div class="flex items-start justify-between mb-3">
               <div class="flex-1">
                 <div class="flex items-center gap-2 mb-2">
-                  <span class="text-lg font-medium text-blue-600 dark:text-blue-400">
-                    #{index + 1}
-                  </span>
+                  <a
+                    href={task.url}
+                    class="text-lg font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200 transition-colors"
+                  >
+                    #{task.issueNumber}
+                  </a>
                   <span
                     class={`px-2 py-1 text-xs rounded-full font-medium ${getPriorityColor(task.priority)}`}
                   >


### PR DESCRIPTION
## 概要

おすすめタスクの表示を改善し、順番表示 (#1, #2, #3) から実際のIssue番号表示に変更し、クリック可能なリンクとして機能するようにしました。

## 変更内容

### UI/UX 改善
- **Issue番号表示**: 順番表示 (#1, #2, #3) → 実際のIssue番号 (#204, #208, #213 等)
- **クリック機能**: Issue番号をクリック可能なリンクに変更
- **ナビゲーション**: クリックするとGitHub Issue ページに直接ジャンプ
- **ユーザビリティ**: ホバー効果とトランジション効果を追加

### 技術的改善
- 未使用の `index` パラメータを削除してlintエラーを解消
- より実用的で直感的なタスク識別方法を提供

## テスト

- ✅ Lint チェック通過
- ✅ Format チェック通過  
- ✅ Type チェック通過
- ✅ 全テスト通過 (1562 tests)
- ✅ Pre-commit フック通過

## 動作確認

開発サーバーで以下を確認：
- Issue番号が正しく表示される
- Issue番号をクリックするとGitHub Issue ページに遷移する
- ホバー効果が正常に動作する

## スクリーンショット/デモ

実際のIssue番号（例：#204, #208, #213）が表示され、クリック可能なリンクとして機能します。

🤖 Generated with [Claude Code](https://claude.ai/code)