### PR TITLE
fix: Codecov履歴データの捏造を削除し実データのみ表示

### DIFF
--- a/src/pages/quality/index.astro
+++ b/src/pages/quality/index.astro
@@ -73,12 +73,11 @@ const moduleCoverageData = qualityData.modules.map(module => ({
   missedLines: module.missedLines,
 }));
 
-// 履歴チャート用データの準備
+// 履歴チャート用データの準備（実データのみ使用）
 const coverageHistoryData = qualityData.history.map(entry => ({
   date: entry.date,
   coverage: entry.coverage,
-  // Add some sample branch coverage data for demonstration
-  branchCoverage: entry.coverage * 0.9, // Typically slightly lower than line coverage
+  // Only add branch coverage if we have actual data, don't fabricate it
 }));
 ---
 
@@ -166,19 +165,47 @@ const coverageHistoryData = qualityData.history.map(entry => ({
 
     <!-- Coverage History Chart (Full Width) -->
     <div class="mb-8">
-      <CoverageHistoryChart
-        data={coverageHistoryData}
-        title="カバレッジ履歴チャート"
-        description="時系列でのカバレッジ変化を可視化"
-        height={400}
-        showMultipleMetrics={true}
-        showTrend={true}
-        goalPercentage={80}
-        defaultPeriod="1m"
-        loading={false}
-        error={errorMessage || undefined}
-        client:load
-      />
+      {
+        coverageHistoryData.length === 0 ? (
+          <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
+            <div class="text-yellow-600 mb-2">
+              <svg
+                class="w-12 h-12 mx-auto mb-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <h3 class="text-lg font-semibold text-yellow-800 mb-2">履歴データなし</h3>
+            <p class="text-yellow-700">
+              Codecov APIから履歴データを取得できませんでした。
+              <br />
+              データが蓄積されるとここにカバレッジの推移が表示されます。
+            </p>
+          </div>
+        ) : (
+          <CoverageHistoryChart
+            data={coverageHistoryData}
+            title="カバレッジ履歴チャート"
+            description="時系列でのカバレッジ変化を可視化"
+            height={400}
+            showMultipleMetrics={true}
+            showTrend={true}
+            goalPercentage={80}
+            defaultPeriod="1m"
+            loading={false}
+            error={errorMessage || undefined}
+            client:load
+          />
+        )
+      }
     </div>
 
     <!-- Module Coverage Analysis -->


### PR DESCRIPTION
## 概要

ユーザー指摘に基づき、Codecov履歴データの偽造部分を削除し、実際に存在するデータのみを表示するように修正しました。

## 問題

従来の実装では：
- 履歴データが不足している場合に、実在しない日付のダミーデータを生成していた
- 偽のブランチカバレッジ値（`coverage * 0.9`）を計算していた
- これらの捏造されたデータが実際のCodecovデータと混在して表示されていた

## 修正内容

### 🗑️ **削除された機能**
- `generateRealisticCoverageHistory()` 関数を完全削除
- 履歴データ不足時のダミーデータ生成ロジックを削除
- 偽のブランチカバレッジ計算を削除

### ✅ **改善された動作**
- **実データのみ表示**: Codecov APIから取得できた実際のデータのみを使用
- **誠実な表示**: データが存在しない場合は空配列を返す
- **適切なUI**: 履歴データが空の場合に説明メッセージを表示

### 📊 **新しいUI**
```
履歴データなし
Codecov APIから履歴データを取得できませんでした。
データが蓄積されるとここにカバレッジの推移が表示されます。
```

## テスト

- ✅ 全品質チェック通過 (lint, format, type-check, test)
- ✅ 空の履歴データでも正常に動作
- ✅ 実データがある場合は正常にチャート表示

## 影響

- **データの信頼性向上**: 存在しないデータを捏造しない正直な表示
- **ユーザー体験向上**: データ不足時の適切な説明メッセージ
- **コード簡素化**: 不要なダミーデータ生成ロジックを削除（-73行, +52行）

この修正により、ユーザーは実際に存在するデータのみを確認でき、
データの信頼性と透明性が向上します。