### PR TITLE
feat: 品質ダッシュボードでカバレッジ閾値による改善モジュール非表示化 (#232)

### DIFF
--- a/src/components/quality/QualityDashboardWithSettings.tsx
+++ b/src/components/quality/QualityDashboardWithSettings.tsx
@@ -1,0 +1,332 @@
+/**
+ * Quality Dashboard with Interactive Settings
+ *
+ * A React component that provides an interactive quality dashboard with
+ * configurable settings for threshold filtering and display options.
+ *
+ * @module QualityDashboardWithSettings
+ */
+
+import React, { useState, useMemo } from 'react';
+import QualitySettings, { useQualitySettings } from '../ui/QualitySettings.tsx';
+
+/**
+ * Module coverage data structure
+ */
+export interface ModuleCoverageData {
+  name: string;
+  coverage: number;
+  lines: number;
+  missedLines: number;
+}
+
+/**
+ * Quality dashboard props
+ */
+export interface QualityDashboardWithSettingsProps {
+  /** Array of module coverage data */
+  modules: ModuleCoverageData[];
+  /** Default attention threshold */
+  defaultThreshold?: number;
+  /** Default display count */
+  defaultDisplayCount?: number;
+  /** CSS class name */
+  className?: string;
+}
+
+/**
+ * Quality Dashboard with Settings Component
+ *
+ * Provides an interactive dashboard with configurable filtering and display options
+ */
+export function QualityDashboardWithSettings({
+  modules,
+  defaultThreshold = 80,
+  defaultDisplayCount = 5,
+  className = '',
+}: QualityDashboardWithSettingsProps) {
+  const [settings, setSettings] = useQualitySettings({
+    attentionThreshold: defaultThreshold,
+    displayCount: defaultDisplayCount,
+  });
+
+  const [isSettingsExpanded, setIsSettingsExpanded] = useState(false);
+
+  // Process modules based on current settings
+  const processedData = useMemo(() => {
+    const modulesNeedingAttention = modules
+      .filter(module => module.coverage < settings.attentionThreshold)
+      .sort((a, b) => a.coverage - b.coverage)
+      .slice(0, settings.displayCount);
+
+    const healthyModules = modules
+      .filter(module => module.coverage >= settings.attentionThreshold)
+      .sort((a, b) => b.coverage - a.coverage)
+      .slice(0, settings.displayCount);
+
+    const qualityAnalysis = {
+      excellent: modules.filter(m => m.coverage >= 90),
+      good: modules.filter(m => m.coverage >= 80 && m.coverage < 90),
+      warning: modules.filter(m => m.coverage >= 50 && m.coverage < 80),
+      critical: modules.filter(m => m.coverage < 50),
+    };
+
+    return {
+      modulesNeedingAttention,
+      healthyModules,
+      qualityAnalysis,
+    };
+  }, [modules, settings]);
+
+  return (
+    <div className={`space-y-6 ${className}`}>
+      {/* Settings Panel */}
+      <QualitySettings
+        settings={settings}
+        onSettingsChange={setSettings}
+        isExpanded={isSettingsExpanded}
+        onToggleExpanded={setIsSettingsExpanded}
+      />
+
+      {/* Quality Analysis Dashboard */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        {/* Modules Needing Attention (Below Threshold) */}
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-6">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              要改善モジュール ({settings.attentionThreshold}%未満)
+            </h2>
+            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300">
+              {processedData.modulesNeedingAttention.length}件
+            </span>
+          </div>
+
+          {processedData.modulesNeedingAttention.length === 0 ? (
+            <div className="p-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-center">
+              <div className="text-green-600 dark:text-green-400 mb-2">
+                <svg
+                  className="w-12 h-12 mx-auto mb-3"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold text-green-800 dark:text-green-200 mb-2">
+                🎉 すべてのモジュールが基準を満たしています
+              </h3>
+              <p className="text-green-700 dark:text-green-300">
+                全モジュールが{settings.attentionThreshold}%以上のカバレッジを達成しています。
+                <br />
+                素晴らしい品質状態です！
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {processedData.modulesNeedingAttention.map((module, index) => (
+                <div
+                  key={module.name}
+                  className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
+                >
+                  <div className="flex justify-between items-start">
+                    <div className="flex-1">
+                      <h3 className="font-medium text-red-900 dark:text-red-200">{module.name}</h3>
+                      <p className="text-sm text-red-700 dark:text-red-300 mt-1">
+                        カバレッジ: {module.coverage.toFixed(1)}% • 未カバー:{' '}
+                        {module.missedLines.toLocaleString()}行 / {module.lines.toLocaleString()}行
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300">
+                        優先度{index + 1}
+                      </span>
+                      <span className="text-2xl">⚠️</span>
+                    </div>
+                  </div>
+                  <div className="mt-3">
+                    <div className="w-full bg-red-200 dark:bg-red-800 rounded-full h-2">
+                      <div
+                        className="bg-red-600 dark:bg-red-500 h-2 rounded-full"
+                        style={{ width: `${module.coverage}%` }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+
+              {modules.filter(m => m.coverage < settings.attentionThreshold).length >
+                settings.displayCount && (
+                <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg text-center">
+                  <p className="text-sm text-yellow-800 dark:text-yellow-300">
+                    他に
+                    {modules.filter(m => m.coverage < settings.attentionThreshold).length -
+                      settings.displayCount}
+                    件の改善対象モジュールがあります
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Healthy Modules (Above Threshold) */}
+        {settings.showHealthyModules && (
+          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-6">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                高品質モジュール ({settings.attentionThreshold}%以上)
+              </h2>
+              <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">
+                {processedData.healthyModules.length}件
+              </span>
+            </div>
+
+            {processedData.healthyModules.length === 0 ? (
+              <div className="p-6 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-lg text-center">
+                <div className="text-orange-600 dark:text-orange-400 mb-2">
+                  <svg
+                    className="w-12 h-12 mx-auto mb-3"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16c-.77.833.192 2.5 1.732 2.5z"
+                    />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-orange-800 dark:text-orange-200 mb-2">
+                  改善の余地があります
+                </h3>
+                <p className="text-orange-700 dark:text-orange-300">
+                  {settings.attentionThreshold}
+                  %以上のカバレッジを達成しているモジュールがありません。
+                  <br />
+                  テストカバレッジの向上が必要です。
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {processedData.healthyModules.map(module => (
+                  <div
+                    key={module.name}
+                    className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg"
+                  >
+                    <div className="flex justify-between items-start">
+                      <div className="flex-1">
+                        <h3 className="font-medium text-green-900 dark:text-green-200">
+                          {module.name}
+                        </h3>
+                        <p className="text-sm text-green-700 dark:text-green-300 mt-1">
+                          カバレッジ: {module.coverage.toFixed(1)}% • カバー済み:{' '}
+                          {(module.lines - module.missedLines).toLocaleString()}行 /{' '}
+                          {module.lines.toLocaleString()}行
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300">
+                          {module.coverage >= 90 ? '🌟優秀' : '✅良好'}
+                        </span>
+                        <span className="text-2xl">{module.coverage >= 90 ? '🌟' : '✅'}</span>
+                      </div>
+                    </div>
+                    <div className="mt-3">
+                      <div className="w-full bg-green-200 dark:bg-green-800 rounded-full h-2">
+                        <div
+                          className="bg-green-600 dark:bg-green-500 h-2 rounded-full"
+                          style={{ width: `${module.coverage}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+
+                {processedData.healthyModules.length > settings.displayCount && (
+                  <div className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-center">
+                    <p className="text-sm text-green-800 dark:text-green-300">
+                      他に{processedData.healthyModules.length - settings.displayCount}
+                      件の高品質モジュールがあります
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Quality Statistics Overview */}
+      {settings.showStatistics && (
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            📊 品質レベル統計
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+            <div className="p-4 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-lg text-center">
+              <div className="text-2xl font-bold text-emerald-800 dark:text-emerald-200">
+                {processedData.qualityAnalysis.excellent.length}
+              </div>
+              <div className="text-sm text-emerald-600 dark:text-emerald-400">優秀 (≥90%)</div>
+              <div className="text-xs text-emerald-500 dark:text-emerald-400 mt-1">🌟</div>
+            </div>
+            <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-center">
+              <div className="text-2xl font-bold text-green-800 dark:text-green-200">
+                {processedData.qualityAnalysis.good.length}
+              </div>
+              <div className="text-sm text-green-600 dark:text-green-400">良好 (80-89%)</div>
+              <div className="text-xs text-green-500 dark:text-green-400 mt-1">✅</div>
+            </div>
+            <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg text-center">
+              <div className="text-2xl font-bold text-yellow-800 dark:text-yellow-200">
+                {processedData.qualityAnalysis.warning.length}
+              </div>
+              <div className="text-sm text-yellow-600 dark:text-yellow-400">要注意 (50-79%)</div>
+              <div className="text-xs text-yellow-500 dark:text-yellow-400 mt-1">⚠️</div>
+            </div>
+            <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-center">
+              <div className="text-2xl font-bold text-red-800 dark:text-red-200">
+                {processedData.qualityAnalysis.critical.length}
+              </div>
+              <div className="text-sm text-red-600 dark:text-red-400">緊急 (&lt;50%)</div>
+              <div className="text-xs text-red-500 dark:text-red-400 mt-1">🚨</div>
+            </div>
+          </div>
+
+          {/* Quality Insights */}
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+            <h3 className="font-medium text-blue-900 dark:text-blue-200 mb-2">💡 品質インサイト</h3>
+            <div className="text-sm text-blue-800 dark:text-blue-300 space-y-1">
+              <p>
+                • <strong>閾値設定:</strong> {settings.attentionThreshold}
+                %未満のモジュールを改善対象として表示
+              </p>
+              <p>
+                • <strong>優先度:</strong> カバレッジが最も低いモジュールから優先的に表示
+              </p>
+              <p>
+                • <strong>表示件数:</strong> 各カテゴリ最大{settings.displayCount}件まで表示
+              </p>
+              {processedData.modulesNeedingAttention.length > 0 && (
+                <p>
+                  • <strong>推奨アクション:</strong>{' '}
+                  要改善モジュールにテストケースを追加してカバレッジを向上
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default QualityDashboardWithSettings;

--- a/src/components/ui/QualitySettings.tsx
+++ b/src/components/ui/QualitySettings.tsx
@@ -1,0 +1,286 @@
+/**
+ * Quality Dashboard Settings Component
+ *
+ * Provides configurable settings for the quality dashboard including
+ * threshold adjustment, display count, and filter options.
+ *
+ * @module QualitySettings
+ */
+
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Quality settings configuration
+ */
+export interface QualitySettingsConfig {
+  /** Coverage threshold for attention filtering (default: 80) */
+  attentionThreshold: number;
+  /** Maximum number of modules to display per category (default: 5) */
+  displayCount: number;
+  /** Whether to show healthy modules section (default: true) */
+  showHealthyModules: boolean;
+  /** Whether to show statistics overview (default: true) */
+  showStatistics: boolean;
+}
+
+/**
+ * Quality settings component props
+ */
+export interface QualitySettingsProps {
+  /** Current settings configuration */
+  settings: QualitySettingsConfig;
+  /** Callback when settings change */
+  onSettingsChange: (settings: QualitySettingsConfig) => void;
+  /** CSS class name */
+  className?: string;
+  /** Whether settings panel is expanded */
+  isExpanded?: boolean;
+  /** Callback when expand/collapse is toggled */
+  onToggleExpanded?: (expanded: boolean) => void;
+}
+
+/**
+ * Default quality settings
+ */
+export const DEFAULT_QUALITY_SETTINGS: QualitySettingsConfig = {
+  attentionThreshold: 80,
+  displayCount: 5,
+  showHealthyModules: true,
+  showStatistics: true,
+};
+
+/**
+ * Quality Settings Component
+ *
+ * Provides an interactive UI for configuring quality dashboard settings
+ */
+export function QualitySettings({
+  settings,
+  onSettingsChange,
+  className = '',
+  isExpanded = false,
+  onToggleExpanded,
+}: QualitySettingsProps) {
+  const [localSettings, setLocalSettings] = useState<QualitySettingsConfig>(settings);
+
+  // Update local settings when props change
+  useEffect(() => {
+    setLocalSettings(settings);
+  }, [settings]);
+
+  // Handle settings change with debouncing
+  const handleSettingChange = (key: keyof QualitySettingsConfig, value: number | boolean) => {
+    const newSettings = { ...localSettings, [key]: value };
+    setLocalSettings(newSettings);
+    onSettingsChange(newSettings);
+  };
+
+  // Preset threshold options
+  const thresholdPresets = [
+    { value: 50, label: '50% (低)', description: '基本的な品質基準' },
+    { value: 70, label: '70% (中)', description: '推奨品質基準' },
+    { value: 80, label: '80% (高)', description: 'デフォルト基準' },
+    { value: 90, label: '90% (最高)', description: '高品質基準' },
+  ];
+
+  // Display count options
+  const displayCountOptions = [3, 5, 10, 15, 20];
+
+  return (
+    <div
+      className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm ${className}`}
+    >
+      {/* Settings Header */}
+      <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center space-x-2">
+          <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center">
+            <span className="text-blue-600 dark:text-blue-400 text-lg">⚙️</span>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              品質ダッシュボード設定
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">表示内容と閾値をカスタマイズ</p>
+          </div>
+        </div>
+
+        {onToggleExpanded && (
+          <button
+            onClick={() => onToggleExpanded(!isExpanded)}
+            className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            aria-label={isExpanded ? '設定を閉じる' : '設定を開く'}
+          >
+            <svg
+              className={`w-5 h-5 transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Settings Content */}
+      {isExpanded && (
+        <div className="p-6 space-y-6">
+          {/* Attention Threshold Setting */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+              改善対象の閾値
+            </label>
+            <div className="space-y-3">
+              {/* Threshold Slider */}
+              <div className="px-3">
+                <input
+                  type="range"
+                  min="10"
+                  max="95"
+                  step="5"
+                  value={localSettings.attentionThreshold}
+                  onChange={e =>
+                    handleSettingChange('attentionThreshold', parseInt(e.target.value))
+                  }
+                  className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer slider"
+                />
+                <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  <span>10%</span>
+                  <span className="font-medium text-blue-600 dark:text-blue-400">
+                    {localSettings.attentionThreshold}%
+                  </span>
+                  <span>95%</span>
+                </div>
+              </div>
+
+              {/* Preset Buttons */}
+              <div className="grid grid-cols-2 gap-2">
+                {thresholdPresets.map(preset => (
+                  <button
+                    key={preset.value}
+                    onClick={() => handleSettingChange('attentionThreshold', preset.value)}
+                    className={`p-3 text-left border rounded-lg transition-colors ${
+                      localSettings.attentionThreshold === preset.value
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
+                        : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500 text-gray-700 dark:text-gray-300'
+                    }`}
+                  >
+                    <div className="font-medium">{preset.label}</div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      {preset.description}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Display Count Setting */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+              表示件数
+            </label>
+            <div className="flex space-x-2">
+              {displayCountOptions.map(count => (
+                <button
+                  key={count}
+                  onClick={() => handleSettingChange('displayCount', count)}
+                  className={`px-4 py-2 rounded-lg border transition-colors ${
+                    localSettings.displayCount === count
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
+                      : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500 text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  {count}件
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Display Options */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+              表示オプション
+            </label>
+            <div className="space-y-3">
+              <label className="flex items-center">
+                <input
+                  type="checkbox"
+                  checked={localSettings.showHealthyModules}
+                  onChange={e => handleSettingChange('showHealthyModules', e.target.checked)}
+                  className="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="ml-3 text-sm text-gray-700 dark:text-gray-300">
+                  高品質モジュールセクションを表示
+                </span>
+              </label>
+
+              <label className="flex items-center">
+                <input
+                  type="checkbox"
+                  checked={localSettings.showStatistics}
+                  onChange={e => handleSettingChange('showStatistics', e.target.checked)}
+                  className="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="ml-3 text-sm text-gray-700 dark:text-gray-300">
+                  品質レベル統計を表示
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* Reset Button */}
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <button
+              onClick={() => onSettingsChange(DEFAULT_QUALITY_SETTINGS)}
+              className="w-full px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            >
+              デフォルト設定にリセット
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Hook for managing quality settings with localStorage persistence
+ */
+export function useQualitySettings(initialSettings?: Partial<QualitySettingsConfig>) {
+  const [settings, setSettings] = useState<QualitySettingsConfig>(() => {
+    // Try to load from localStorage
+    if (typeof window !== 'undefined') {
+      try {
+        const saved = localStorage.getItem('beaver-quality-settings');
+        if (saved) {
+          const parsed = JSON.parse(saved);
+          return { ...DEFAULT_QUALITY_SETTINGS, ...parsed, ...initialSettings };
+        }
+      } catch (error) {
+        console.warn('Failed to load quality settings from localStorage:', error);
+      }
+    }
+    return { ...DEFAULT_QUALITY_SETTINGS, ...initialSettings };
+  });
+
+  // Save to localStorage whenever settings change
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        localStorage.setItem('beaver-quality-settings', JSON.stringify(settings));
+      } catch (error) {
+        console.warn('Failed to save quality settings to localStorage:', error);
+      }
+    }
+  }, [settings]);
+
+  return [settings, setSettings] as const;
+}
+
+export default QualitySettings;

--- a/src/components/ui/__tests__/QualitySettings.test.tsx
+++ b/src/components/ui/__tests__/QualitySettings.test.tsx
@@ -1,0 +1,363 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QualitySettings, {
+  useQualitySettings,
+  DEFAULT_QUALITY_SETTINGS,
+} from '../QualitySettings.tsx';
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('QualitySettings', () => {
+  const mockOnSettingsChange = vi.fn();
+  const mockOnToggleExpanded = vi.fn();
+
+  const defaultProps = {
+    settings: DEFAULT_QUALITY_SETTINGS,
+    onSettingsChange: mockOnSettingsChange,
+    isExpanded: true,
+    onToggleExpanded: mockOnToggleExpanded,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders settings header correctly', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    expect(screen.getByText('品質ダッシュボード設定')).toBeInTheDocument();
+    expect(screen.getByText('表示内容と閾値をカスタマイズ')).toBeInTheDocument();
+    expect(screen.getByLabelText('設定を閉じる')).toBeInTheDocument();
+  });
+
+  it('renders collapsed state correctly', () => {
+    render(<QualitySettings {...defaultProps} isExpanded={false} />);
+
+    expect(screen.getByText('品質ダッシュボード設定')).toBeInTheDocument();
+    expect(screen.queryByText('改善対象の閾値')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('設定を開く')).toBeInTheDocument();
+  });
+
+  it('toggles expanded state when button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<QualitySettings {...defaultProps} isExpanded={false} />);
+
+    const toggleButton = screen.getByLabelText('設定を開く');
+    await user.click(toggleButton);
+
+    expect(mockOnToggleExpanded).toHaveBeenCalledWith(true);
+  });
+
+  it('renders threshold slider with correct value', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    expect(screen.getByText('改善対象の閾値')).toBeInTheDocument();
+
+    const slider = screen.getByDisplayValue('80');
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute('type', 'range');
+    expect(slider).toHaveAttribute('min', '10');
+    expect(slider).toHaveAttribute('max', '95');
+    expect(slider).toHaveAttribute('step', '5');
+  });
+
+  it('updates threshold when slider is changed', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    const slider = screen.getByDisplayValue('80');
+    fireEvent.change(slider, { target: { value: '70' } });
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      ...DEFAULT_QUALITY_SETTINGS,
+      attentionThreshold: 70,
+    });
+  });
+
+  it('renders threshold preset buttons', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    expect(screen.getByText('50% (低)')).toBeInTheDocument();
+    expect(screen.getByText('70% (中)')).toBeInTheDocument();
+    expect(screen.getByText('80% (高)')).toBeInTheDocument();
+    expect(screen.getByText('90% (最高)')).toBeInTheDocument();
+  });
+
+  it('updates threshold when preset button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<QualitySettings {...defaultProps} />);
+
+    const preset70Button = screen.getByText('70% (中)').closest('button');
+    expect(preset70Button).toBeInTheDocument();
+
+    await user.click(preset70Button!);
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      ...DEFAULT_QUALITY_SETTINGS,
+      attentionThreshold: 70,
+    });
+  });
+
+  it('highlights active preset button', () => {
+    const settingsWithDifferentThreshold = {
+      ...DEFAULT_QUALITY_SETTINGS,
+      attentionThreshold: 70,
+    };
+
+    render(<QualitySettings {...defaultProps} settings={settingsWithDifferentThreshold} />);
+
+    const preset70Button = screen.getByText('70% (中)').closest('button');
+    const preset80Button = screen.getByText('80% (高)').closest('button');
+
+    expect(preset70Button).toHaveClass('border-blue-500', 'bg-blue-50');
+    expect(preset80Button).not.toHaveClass('border-blue-500', 'bg-blue-50');
+  });
+
+  it('renders display count options', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    expect(screen.getByText('表示件数')).toBeInTheDocument();
+    expect(screen.getByText('3件')).toBeInTheDocument();
+    expect(screen.getByText('5件')).toBeInTheDocument();
+    expect(screen.getByText('10件')).toBeInTheDocument();
+    expect(screen.getByText('15件')).toBeInTheDocument();
+    expect(screen.getByText('20件')).toBeInTheDocument();
+  });
+
+  it('updates display count when button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<QualitySettings {...defaultProps} />);
+
+    const count10Button = screen.getByText('10件');
+    await user.click(count10Button);
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      ...DEFAULT_QUALITY_SETTINGS,
+      displayCount: 10,
+    });
+  });
+
+  it('highlights active display count button', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    const count5Button = screen.getByText('5件');
+    const count10Button = screen.getByText('10件');
+
+    expect(count5Button).toHaveClass('border-blue-500', 'bg-blue-50');
+    expect(count10Button).not.toHaveClass('border-blue-500', 'bg-blue-50');
+  });
+
+  it('renders display options checkboxes', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    expect(screen.getByText('表示オプション')).toBeInTheDocument();
+    expect(screen.getByText('高品質モジュールセクションを表示')).toBeInTheDocument();
+    expect(screen.getByText('品質レベル統計を表示')).toBeInTheDocument();
+
+    const healthyModulesCheckbox = screen.getByLabelText('高品質モジュールセクションを表示');
+    const statisticsCheckbox = screen.getByLabelText('品質レベル統計を表示');
+
+    expect(healthyModulesCheckbox).toBeChecked();
+    expect(statisticsCheckbox).toBeChecked();
+  });
+
+  it('updates display options when checkboxes are toggled', async () => {
+    const user = userEvent.setup();
+    render(<QualitySettings {...defaultProps} />);
+
+    const healthyModulesCheckbox = screen.getByLabelText('高品質モジュールセクションを表示');
+    await user.click(healthyModulesCheckbox);
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      ...DEFAULT_QUALITY_SETTINGS,
+      showHealthyModules: false,
+    });
+  });
+
+  it('renders reset button', () => {
+    render(<QualitySettings {...defaultProps} />);
+
+    expect(screen.getByText('デフォルト設定にリセット')).toBeInTheDocument();
+  });
+
+  it('resets settings when reset button is clicked', async () => {
+    const user = userEvent.setup();
+    const customSettings = {
+      attentionThreshold: 70,
+      displayCount: 10,
+      showHealthyModules: false,
+      showStatistics: false,
+    };
+
+    render(<QualitySettings {...defaultProps} settings={customSettings} />);
+
+    const resetButton = screen.getByText('デフォルト設定にリセット');
+    await user.click(resetButton);
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith(DEFAULT_QUALITY_SETTINGS);
+  });
+
+  it('applies custom className', () => {
+    const customClass = 'custom-settings-class';
+    const { container } = render(<QualitySettings {...defaultProps} className={customClass} />);
+
+    expect(container.firstChild).toHaveClass(customClass);
+  });
+
+  it('works without onToggleExpanded callback', () => {
+    render(
+      <QualitySettings
+        settings={DEFAULT_QUALITY_SETTINGS}
+        onSettingsChange={mockOnSettingsChange}
+        isExpanded={true}
+      />
+    );
+
+    expect(screen.queryByLabelText('設定を閉じる')).not.toBeInTheDocument();
+  });
+});
+
+describe('useQualitySettings', () => {
+  const TestComponent = () => {
+    const [settings, setSettings] = useQualitySettings();
+
+    return (
+      <div>
+        <div data-testid="threshold">{settings.attentionThreshold}</div>
+        <div data-testid="displayCount">{settings.displayCount}</div>
+        <div data-testid="showHealthy">{settings.showHealthyModules.toString()}</div>
+        <div data-testid="showStats">{settings.showStatistics.toString()}</div>
+        <button
+          onClick={() =>
+            setSettings({
+              ...settings,
+              attentionThreshold: 70,
+            })
+          }
+          data-testid="updateButton"
+        >
+          Update
+        </button>
+      </div>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+  });
+
+  it('returns default settings initially', () => {
+    render(<TestComponent />);
+
+    expect(screen.getByTestId('threshold')).toHaveTextContent('80');
+    expect(screen.getByTestId('displayCount')).toHaveTextContent('5');
+    expect(screen.getByTestId('showHealthy')).toHaveTextContent('true');
+    expect(screen.getByTestId('showStats')).toHaveTextContent('true');
+  });
+
+  it('loads settings from localStorage', () => {
+    const savedSettings = {
+      attentionThreshold: 70,
+      displayCount: 10,
+      showHealthyModules: false,
+      showStatistics: false,
+    };
+
+    localStorageMock.getItem.mockReturnValue(JSON.stringify(savedSettings));
+
+    render(<TestComponent />);
+
+    expect(screen.getByTestId('threshold')).toHaveTextContent('70');
+    expect(screen.getByTestId('displayCount')).toHaveTextContent('10');
+    expect(screen.getByTestId('showHealthy')).toHaveTextContent('false');
+    expect(screen.getByTestId('showStats')).toHaveTextContent('false');
+  });
+
+  it('saves settings to localStorage when updated', async () => {
+    const user = userEvent.setup();
+    render(<TestComponent />);
+
+    const updateButton = screen.getByTestId('updateButton');
+    await user.click(updateButton);
+
+    await waitFor(() => {
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'beaver-quality-settings',
+        JSON.stringify({
+          ...DEFAULT_QUALITY_SETTINGS,
+          attentionThreshold: 70,
+        })
+      );
+    });
+  });
+
+  it('handles localStorage errors gracefully', () => {
+    localStorageMock.getItem.mockImplementation(() => {
+      throw new Error('localStorage error');
+    });
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(<TestComponent />);
+
+    expect(screen.getByTestId('threshold')).toHaveTextContent('80');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load quality settings from localStorage:',
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles localStorage save errors gracefully', async () => {
+    const user = userEvent.setup();
+    localStorageMock.setItem.mockImplementation(() => {
+      throw new Error('localStorage save error');
+    });
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(<TestComponent />);
+
+    const updateButton = screen.getByTestId('updateButton');
+    await user.click(updateButton);
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to save quality settings to localStorage:',
+        expect.any(Error)
+      );
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('works with initial settings override', () => {
+    const TestComponentWithInitial = () => {
+      const [settings] = useQualitySettings({ attentionThreshold: 60 });
+      return <div data-testid="threshold">{settings.attentionThreshold}</div>;
+    };
+
+    render(<TestComponentWithInitial />);
+
+    expect(screen.getByTestId('threshold')).toHaveTextContent('60');
+  });
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -25,6 +25,10 @@ export type {
   FormValidation,
 } from '../../lib/schemas/ui';
 
+// Quality settings component
+export { default as QualitySettings, useQualitySettings } from './QualitySettings.tsx';
+export type { QualitySettingsConfig, QualitySettingsProps } from './QualitySettings.tsx';
+
 // UI component metadata
 export const UI_COMPONENTS = {
   Button: {

--- a/src/pages/quality/index.astro
+++ b/src/pages/quality/index.astro
@@ -12,6 +12,7 @@ import PageLayout from '../../components/layouts/PageLayout.astro';
 import PageHeader from '../../components/ui/PageHeader.astro';
 import ModuleCoverageChart from '../../components/charts/ModuleCoverageChart.tsx';
 import CoverageHistoryChart from '../../components/charts/CoverageHistoryChart.tsx';
+import QualityDashboardWithSettings from '../../components/quality/QualityDashboardWithSettings.tsx';
 import { getQualityMetrics } from '../../lib/quality/codecov';
 
 const title = '品質分析ダッシュボード';
@@ -60,10 +61,9 @@ try {
   };
 }
 
-// 対処が必要な上位5モジュールを特定
-const modulesNeedingAttention = qualityData.modules
-  .sort((a, b) => a.coverage - b.coverage)
-  .slice(0, 5);
+// 設定可能な閾値による品質分析
+const DEFAULT_ATTENTION_THRESHOLD = 80; // デフォルト閾値を80%に設定
+const DEFAULT_DISPLAY_COUNT = 5;
 
 // モジュール別カバレッジチャート用データの準備
 const moduleCoverageData = qualityData.modules.map(module => ({
@@ -213,11 +213,11 @@ const coverageHistoryData = qualityData.history.map(entry => ({
       <ModuleCoverageChart
         data={moduleCoverageData}
         title="モジュール別カバレッジ分析"
-        description="全モジュールのカバレッジ状況（低い順に表示）"
+        description={`閾値${DEFAULT_ATTENTION_THRESHOLD}%でのカバレッジ状況（低い順に表示）`}
         height={400}
         showPercentage={true}
         showValues={true}
-        threshold={50}
+        threshold={DEFAULT_ATTENTION_THRESHOLD}
         maxModules={10}
         sortOrder="asc"
         loading={false}
@@ -226,82 +226,13 @@ const coverageHistoryData = qualityData.history.map(entry => ({
       />
     </div>
 
-    <!-- Modules Needing Attention -->
-    <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-      <div class="card">
-        <h2 class="text-lg font-semibold text-heading mb-4">対処が必要な上位5モジュール</h2>
-        <div class="space-y-4">
-          {
-            modulesNeedingAttention.map((module, index) => (
-              <div class="p-4 bg-red-50 border border-red-200 rounded-lg">
-                <div class="flex justify-between items-start">
-                  <div class="flex-1">
-                    <h3 class="font-medium text-red-900">{module.name}</h3>
-                    <p class="text-sm text-red-700 mt-1">
-                      カバレッジ: {module.coverage.toFixed(1)}% • 未カバー: {module.missedLines}行 /{' '}
-                      {module.lines}行
-                    </p>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                      {index + 1}位
-                    </span>
-                    <span class="text-2xl">⚠️</span>
-                  </div>
-                </div>
-                <div class="mt-3">
-                  <div class="w-full bg-red-200 rounded-full h-2">
-                    <div class="bg-red-600 h-2 rounded-full" style={`width: ${module.coverage}%`} />
-                  </div>
-                </div>
-              </div>
-            ))
-          }
-        </div>
-      </div>
-
-      <!-- Quality Summary -->
-      <div class="card">
-        <h2 class="text-lg font-semibold text-heading mb-4">品質サマリー</h2>
-        <div class="space-y-4">
-          <div class="p-4 bg-gray-50 rounded-lg">
-            <h3 class="font-medium text-gray-900 mb-2">カバレッジ分析</h3>
-            <ul class="text-sm text-gray-700 space-y-1">
-              <li>• 総合カバレッジ: {qualityData.overallCoverage.toFixed(1)}%</li>
-              <li>• ブランチカバレッジ: {qualityData.branchCoverage.toFixed(1)}%</li>
-              <li>• ライン数: {qualityData.totalLines.toLocaleString()}行</li>
-              <li>• 分析済みモジュール: {qualityData.modules.length}個</li>
-            </ul>
-          </div>
-
-          <div class="p-4 bg-blue-50 rounded-lg">
-            <h3 class="font-medium text-blue-900 mb-2">推奨事項</h3>
-            <ul class="text-sm text-blue-800 space-y-1">
-              <li>• 低カバレッジモジュールにテストを追加</li>
-              <li>• 50%未満のモジュールを優先的に改善</li>
-              <li>• 定期的なカバレッジ監視を実施</li>
-              <li>• CI/CDパイプラインにカバレッジ閾値を設定</li>
-            </ul>
-          </div>
-
-          <div class="p-4 bg-green-50 rounded-lg">
-            <h3 class="font-medium text-green-900 mb-2">高カバレッジモジュール</h3>
-            <ul class="text-sm text-green-800 space-y-1">
-              {
-                qualityData.modules
-                  .filter(m => m.coverage >= 80)
-                  .slice(0, 3)
-                  .map(module => (
-                    <li>
-                      • {module.name}: {module.coverage.toFixed(1)}%
-                    </li>
-                  ))
-              }
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
+    <!-- Interactive Quality Dashboard with Settings -->
+    <QualityDashboardWithSettings
+      modules={moduleCoverageData}
+      defaultThreshold={DEFAULT_ATTENTION_THRESHOLD}
+      defaultDisplayCount={DEFAULT_DISPLAY_COUNT}
+      client:load
+    />
 
     <!-- API Status -->
     <div class="card">


### PR DESCRIPTION
## 概要

Issue #232の解決: 品質ダッシュボードでカバレッジ閾値を超えたモジュールの非表示化機能を実装。デフォルト80%閾値により、要改善モジュールのみに注意を集中可能に。

## 変更内容

### 新規コンポーネント
- **QualitySettings.tsx**: 設定可能な閾値UI（スライダー・プリセット・表示オプション）
- **QualityDashboardWithSettings.tsx**: インタラクティブ品質ダッシュボード
- **QualitySettings.test.tsx**: 包括的テストスイート（23テスト）

### 主要機能
- **閾値ベースフィルタリング**: デフォルト80%、10-95%可変設定
- **要改善モジュール分離**: 閾値未満のみ表示で開発者の注意を集中
- **高品質モジュール表示**: 閾値以上の成功例を別セクションで表示
- **品質レベル統計**: 優秀(≥90%)・良好(80-89%)・要注意(50-79%)・緊急(<50%)
- **表示件数カスタマイズ**: 3/5/10/15/20件選択可能
- **localStorage永続化**: ユーザー設定保存で次回起動時復元

### UI/UX改善
- **設定パネル展開/折りたたみ**: 必要時のみ設定表示
- **プリセット閾値**: 50%(低)・70%(中)・80%(高)・90%(最高)
- **状況別メッセージ**: 全モジュール達成時の祝福メッセージ
- **ダークモード対応**: 全コンポーネントでテーマ切り替え対応

### 技術的改善
- TypeScript完全型安全性
- React Testing Library活用テスト
- localStorage例外処理
- Chart.js閾値連携更新

## テスト

- ✅ 全1670テスト通過（新規23テスト追加）
- ✅ QualitySettings: スライダー、プリセット、チェックボックス操作
- ✅ useQualitySettings: localStorage読み書きと例外処理
- ✅ TypeScript型チェック・Linting・フォーマット通過
- ✅ Pre-commitフック全項目クリア

## Before/After

**Before**: 全モジュール表示（80%+含む）で改善対象が不明確
**After**: 80%未満のみ表示で真の改善対象に集中、設定でカスタマイズ可

Closes #232