### PR TITLE
fix: GitHub Pagesサブフォルダ対応でドキュメントリンクを修正

### DIFF
--- a/docs.config.ts
+++ b/docs.config.ts
@@ -31,21 +31,21 @@ export const docsConfig: DocsConfig = {
     quickLinks: [
       {
         title: 'クイックスタート',
-        href: '/docs/readme',
+        href: '/beaver/docs/readme',
         icon: '🚀',
         description: 'GitHub Actionとして数分で導入',
         color: 'blue',
       },
       {
         title: '開発者ガイド',
-        href: '/docs/local-development',
+        href: '/beaver/docs/local-development',
         icon: '🛠️',
         description: 'ローカル開発とカスタマイズ',
         color: 'green',
       },
       {
         title: '詳細設定',
-        href: '/docs/configuration',
+        href: '/beaver/docs/configuration',
         icon: '🔧',
         description: '高度な機能とセキュリティ',
         color: 'purple',
@@ -62,7 +62,7 @@ export const docsConfig: DocsConfig = {
   
   paths: {
     docsDir: 'docs',
-    baseUrl: '/docs',
+    baseUrl: '/beaver/docs',
   },
   
   search: {

--- a/src/components/docs/DocsLayout.astro
+++ b/src/components/docs/DocsLayout.astro
@@ -32,6 +32,22 @@ const pathConfig = await getPathConfig();
 const projectTitle = `${projectInfo.emoji || ''} ${projectInfo.name} ${t('docs.title')}`.trim();
 const docsBaseUrl = await buildNavUrl('');
 
+// Pre-build navigation URLs
+const navigationWithUrls = await Promise.all(
+  navigation.map(async navItem => ({
+    ...navItem,
+    href: navItem.slug ? await buildNavUrl(navItem.slug) : undefined,
+    children: navItem.children
+      ? await Promise.all(
+          navItem.children.map(async child => ({
+            ...child,
+            href: await buildNavUrl(child.slug),
+          }))
+        )
+      : undefined,
+  }))
+);
+
 // Prepare search configuration for client-side
 const searchConfig = {
   placeholder: config.search?.placeholder || t('docs.search.placeholder'),
@@ -69,7 +85,7 @@ const searchConfig = {
       <nav>
         <ul class="space-y-1">
           {
-            navigation.map(navItem => (
+            navigationWithUrls.map(navItem => (
               <li>
                 {navItem.children ? (
                   /* Category with children */
@@ -79,7 +95,7 @@ const searchConfig = {
                       {navItem.children.map(child => (
                         <li>
                           <a
-                            href={`/docs/${child.slug}`}
+                            href={child.href}
                             class={`block px-3 py-1 text-sm rounded-md transition-colors ${
                               doc.slug === child.slug
                                 ? 'bg-blue-100 text-blue-700 font-medium'
@@ -95,7 +111,7 @@ const searchConfig = {
                 ) : (
                   /* Single navigation item */
                   <a
-                    href={`/docs/${navItem.slug}`}
+                    href={navItem.href}
                     class={`block px-3 py-2 text-sm rounded-md transition-colors ${
                       doc.slug === navItem.slug
                         ? 'bg-blue-100 text-blue-700 font-medium'
@@ -194,7 +210,7 @@ const searchConfig = {
         <nav>
           <ul class="space-y-1">
             {
-              navigation.map(navItem => (
+              navigationWithUrls.map(navItem => (
                 <li>
                   {navItem.children ? (
                     <div>
@@ -203,7 +219,7 @@ const searchConfig = {
                         {navItem.children.map(child => (
                           <li>
                             <a
-                              href={`/docs/${child.slug}`}
+                              href={child.href}
                               class={`block px-3 py-1 text-sm rounded-md transition-colors ${
                                 doc.slug === child.slug
                                   ? 'bg-blue-100 text-blue-700 font-medium'
@@ -218,7 +234,7 @@ const searchConfig = {
                     </div>
                   ) : (
                     <a
-                      href={`/docs/${navItem.slug}`}
+                      href={navItem.href}
                       class={`block px-3 py-2 text-sm rounded-md transition-colors ${
                         doc.slug === navItem.slug
                           ? 'bg-blue-100 text-blue-700 font-medium'

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -31,6 +31,22 @@ const t = await getTranslator();
 const projectInfo = await getProjectInfo();
 const uiConfig = await getUIConfig();
 
+// Pre-build breadcrumb URLs
+const breadcrumbsWithUrls = await Promise.all(
+  doc.breadcrumbs.slice(1).map(async crumb => ({
+    ...crumb,
+    href: await buildNavUrl(crumb.slug),
+  }))
+);
+
+// Pre-build related docs URLs
+const relatedDocsWithUrls = await Promise.all(
+  doc.relatedDocs.map(async relatedSlug => ({
+    slug: relatedSlug,
+    href: await buildNavUrl(relatedSlug),
+  }))
+);
+
 if (!doc) {
   const docsBaseUrl = await buildNavUrl('');
   return Astro.redirect(docsBaseUrl);
@@ -47,10 +63,10 @@ const pageDescription = doc.metadata.description || `${doc.metadata.title}に関
       <ol class="flex items-center space-x-2 text-gray-500">
         <li><a href={await buildNavUrl('')} class="hover:text-blue-600">{t('docs.title')}</a></li>
         {
-          doc.breadcrumbs.slice(1).map((crumb, _index) => (
+          breadcrumbsWithUrls.map((crumb, _index) => (
             <li class="flex items-center space-x-2">
               <span>/</span>
-              <a href={`/docs/${crumb.slug}`} class="hover:text-blue-600">
+              <a href={crumb.href} class="hover:text-blue-600">
                 {crumb.title}
               </a>
             </li>
@@ -184,14 +200,14 @@ const pageDescription = doc.metadata.description || `${doc.metadata.title}に関
         <section class="mt-12">
           <h2 class="text-2xl font-semibold text-gray-900 mb-4">関連ドキュメント</h2>
           <div class="grid md:grid-cols-2 gap-4">
-            {doc.relatedDocs.slice(0, 4).map(relatedSlug => {
+            {relatedDocsWithUrls.slice(0, 4).map(relatedDoc => {
               // This would need to be enhanced to fetch related doc metadata
               return (
                 <a
-                  href={`/docs/${relatedSlug}`}
+                  href={relatedDoc.href}
                   class="p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-sm transition-all"
                 >
-                  <div class="font-medium text-gray-900">{relatedSlug}</div>
+                  <div class="font-medium text-gray-900">{relatedDoc.slug}</div>
                 </a>
               );
             })}

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -5,7 +5,12 @@
 
 import PageLayout from '../../components/layouts/PageLayout.astro';
 import { DocsService } from '../../lib/services/DocsService.js';
-import { getTranslator, getProjectInfo, getNavigationConfig } from '../../lib/config/docs.js';
+import {
+  getTranslator,
+  getProjectInfo,
+  getNavigationConfig,
+  buildNavUrl,
+} from '../../lib/config/docs.js';
 
 // Load configuration and translations
 const t = await getTranslator();
@@ -28,11 +33,18 @@ const categoryTitles = navConfig.categories || {
   overview: t('category.overview'),
 };
 
-const categoriesArray = Object.entries(docsCollection.categories).map(([categoryKey, docs]) => ({
-  key: categoryKey,
-  title: categoryTitles[categoryKey] || categoryKey,
-  docs,
-}));
+const categoriesArray = await Promise.all(
+  Object.entries(docsCollection.categories).map(async ([categoryKey, docs]) => ({
+    key: categoryKey,
+    title: categoryTitles[categoryKey] || categoryKey,
+    docs: await Promise.all(
+      docs.map(async doc => ({
+        ...doc,
+        href: await buildNavUrl(doc.slug),
+      }))
+    ),
+  }))
+);
 
 // Quick links removed as per user feedback
 ---
@@ -62,7 +74,7 @@ const categoriesArray = Object.entries(docsCollection.categories).map(([category
                 <div class="border border-gray-200 rounded-lg hover:shadow-lg transition-shadow bg-white">
                   <div class="p-6">
                     <h3 class="font-semibold text-lg mb-2 text-gray-900">
-                      <a href={`/docs/${doc.slug}`} class="hover:text-blue-600 transition-colors">
+                      <a href={doc.href} class="hover:text-blue-600 transition-colors">
                         {doc.title}
                       </a>
                     </h3>


### PR DESCRIPTION
## Summary

GitHub Pagesのサブフォルダ（`/beaver/`）環境で、ドキュメントページの全てのリンクが404になる問題を修正しました。

### 🐛 問題

- デプロイURL: https://nyasuto.github.io/beaver/docs/
- 全てのドキュメントリンクが `/docs/` で始まっており、サブフォルダパスを考慮していない
- 結果として全てのページリンクが404エラー

### 🔧 解決策

**設定修正:**
- `docs.config.ts`: `baseUrl` を `/docs` → `/beaver/docs` に変更
- `quickLinks` のhrefパスも `/beaver/docs/` 形式に統一

**コンポーネント修正:**
- 全てのリンク生成で `buildNavUrl()` 関数を使用
- Astro JSX制約によりawaitが使えないため、事前にURL構築
- ナビゲーション、ブレッドクラム、関連ドキュメントなど全箇所で対応

### 📋 修正ファイル

- `docs.config.ts` - baseUrl設定とquickLinks
- `DocsLayout.astro` - サイドバーナビゲーション（デスクトップ・モバイル）
- `index.astro` - ドキュメント一覧ページのリンク
- `[...slug].astro` - ブレッドクラムと関連ドキュメント

### ✅ 確認事項

- [x] 全ての品質チェック通過（1702テスト成功）
- [x] TypeScript型チェック完全通過
- [x] GitHub Pagesでの正常動作確認予定

### 🎯 期待される結果

デプロイ後、https://nyasuto.github.io/beaver/docs/ で全てのリンクが正常に動作するはずです。

🤖 Generated with [Claude Code](https://claude.ai/code)