### PR TITLE
fix: docs.config.tsのURL検証エラー修正とGitHub Pagesサブフォルダリンク問題解決

### DIFF
--- a/docs.config.ts
+++ b/docs.config.ts
@@ -12,7 +12,7 @@ export const docsConfig: DocsConfig = {
     description: 'Beaverの完全なドキュメント集 - セットアップから高度な機能まで',
     githubUrl: 'https://github.com/nyasuto/beaver',
     editBaseUrl: 'https://github.com/nyasuto/beaver/edit/main',
-    homeUrl: '/',
+    homeUrl: '/beaver/',
   },
   
   ui: {

--- a/src/lib/types/docs-config.ts
+++ b/src/lib/types/docs-config.ts
@@ -14,7 +14,7 @@ export const ProjectConfigSchema = z.object({
   description: z.string().optional(),
   githubUrl: z.string().url().optional(),
   editBaseUrl: z.string().url().optional(),
-  homeUrl: z.string().url().optional(),
+  homeUrl: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## 概要

GitHub Pagesのサブフォルダデプロイメントで発生していたドキュメントリンクの404問題を修正しました。

## 変更内容

- **Zodバリデーション修正**: `homeUrl`の厳密なURL検証を通常の文字列検証に変更
- **TypeScript設定読み込み修正**: docs.config.tsの読み込みエラーを解決
- **本番環境での正しいリンク生成**: `/beaver/docs`プレフィックスが正しく適用されるように修正

## 技術的詳細

### 根本原因
1. `homeUrl: '/'`がZodの`z.string().url()`検証で無効URLとして扱われていた
2. これによりTypeScript設定の読み込みが失敗し、フォールバック設定（`/docs`）が使用されていた
3. 結果として本番環境でリンクに`/beaver/`プレフィックスが含まれず404エラーが発生

### 修正内容
- `homeUrl`のZodスキーマを`z.string().url()`から`z.string()`に変更
- 相対パスも受け入れるように柔軟性を向上

## テスト

- ローカルでの動作確認: ✅ `/beaver/docs/configuration`等の正しいURL生成を確認
- 品質チェック: ✅ 1702テスト成功、型チェック・リンター通過

🤖 Generated with [Claude Code](https://claude.ai/code)