### PR TITLE
docs: Claude Code用の重要なGitHub操作制限ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,25 @@ Beaver Astro + TypeScript project guidance for Claude Code (claude.ai/code)
 
 **Tech Stack**: Astro 4.0+ | TypeScript 5.0+ | Octokit | Zod | Tailwind CSS
 
+## 🚫 CRITICAL: GitHub Operations Restrictions
+
+**最重要ルール: Claude Codeは以下の操作を決して行ってはいけません**
+
+### 🔴 絶対禁止事項
+1. **Pull Requestのマージ** - ユーザーのみが判断・実行する
+2. **Issueのクローズ** - ユーザーのみが判断・実行する  
+3. **ブランチの削除** - ユーザーのみが判断・実行する
+4. **リリースの作成** - ユーザーのみが判断・実行する
+
+### ✅ Claude Codeが実行可能な操作
+- Pull Requestの作成
+- Issueの作成
+- ブランチの作成
+- コミットの作成とプッシュ
+- CI/CDの実行確認（状況報告のみ）
+
+**理由**: これらの操作はプロジェクトの方向性や品質に重大な影響を与えるため、必ずユーザーの明示的な判断と承認が必要です。
+
 ## 🔄 Pull Request Creation Rule
 
 **CRITICAL: コード変更後は必ずPull Requestを作成する**
@@ -17,6 +36,7 @@ Beaver Astro + TypeScript project guidance for Claude Code (claude.ai/code)
 2. 品質チェック実行 (`npm run quality`)
 3. 変更をコミット
 4. **Pull Request作成** (絶対に忘れてはいけない)
+5. ⚠️ **ユーザーによる承認・マージ待ち** (Claude Codeはマージしない)
 
 ### PR作成チェックリスト
 - [ ] すべてのコード変更が完了している
@@ -24,6 +44,7 @@ Beaver Astro + TypeScript project guidance for Claude Code (claude.ai/code)
 - [ ] 適切なブランチ名になっている
 - [ ] PR説明が適切に記載されている
 - [ ] 関連するIssueが参照されている
+- [ ] ユーザーに承認・マージを依頼
 
 ## 🏗 AI-First Design Principles
 


### PR DESCRIPTION
## 概要

Claude Codeが実行してはいけない重要なGitHub操作について、CLAUDE.mdに明確なルールを追加しました。これにより、プロジェクトの方向性や品質に影響する操作の適切な権限管理を確立します。

## 追加された制限ルール

### 🔴 絶対禁止事項（Claude Code実行不可）
1. **Pull Requestのマージ** - ユーザーのみが判断・実行する
2. **Issueのクローズ** - ユーザーのみが判断・実行する  
3. **ブランチの削除** - ユーザーのみが判断・実行する
4. **リリースの作成** - ユーザーのみが判断・実行する

### ✅ Claude Code実行可能な操作
- Pull Requestの作成
- Issueの作成
- ブランチの作成
- コミットの作成とプッシュ
- CI/CDの実行確認（状況報告のみ）

## 変更の理由

これらの操作はプロジェクトの方向性や品質に重大な影響を与えるため、必ずユーザーの明示的な判断と承認が必要です。AIエージェントによる自動実行ではなく、人間による慎重な判断が求められます。

## 影響

- ✅ Claude Codeの作業範囲が明確化
- ✅ ユーザーの最終決定権が保護される
- ✅ プロジェクトの品質管理が向上
- ✅ 意図しない変更やマージの防止

## テスト

- ✅ 品質チェック: 1702テスト成功
- ✅ 型チェック・リンター通過
- ✅ フォーマット確認完了

この重要なルールをご確認いただき、承認後にマージをお願いいたします。

🤖 Generated with [Claude Code](https://claude.ai/code)