### PR TITLE
fix: site-subdirectoryパラメータでヘッダーリンクを動的に設定

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ runs:
         # Public site URL for GitHub Pages
         echo "PUBLIC_SITE_URL=https://${{ github.repository_owner }}.github.io/${{ inputs.site-subdirectory }}" >> $GITHUB_ENV
         echo "PUBLIC_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
+        
+        # Set BASE_URL for Astro
+        echo "BASE_URL=/${{ inputs.site-subdirectory }}" >> $GITHUB_ENV
     
     - name: Create Beaver workspace
       shell: bash

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
   ],
   output: 'static',
   site: 'https://nyasuto.github.io',
-  base: '/beaver',
+  base: process.env.BASE_URL || '/beaver',
   build: {
     assets: 'assets',
     // Performance optimizations


### PR DESCRIPTION
## 概要

PoC結果で報告されたヘッダーバナーリンクの問題を修正。GitHub Actionの`site-subdirectory`パラメータを使用してヘッダーナビゲーションリンクが動的に適切なプロジェクトパスを反映するように修正。

## 変更内容

### 1. GitHub Action環境変数設定 (action.yml:75)
- `BASE_URL`環境変数を`site-subdirectory`パラメータから自動設定
- Astroビルド時に正しいベースパスが使用されるように修正

### 2. Astro設定の動的化 (astro.config.mjs:14)
- ハードコードされた`base: '/beaver'`を`process.env.BASE_URL || '/beaver'`に変更
- 環境変数によるベースパス設定とフォールバック機能を追加

## 問題解決

- **修正前**: ヘッダーリンクが常に`/beaver/`パスを表示
- **修正後**: デプロイ先リポジトリのサブディレクトリパス（例：`/pug/`）を動的に反映

## テスト

- 品質チェック (npm run quality) が正常に通過 (1702 tests successful)
- URL解決ロジック (`src/lib/utils/url.ts`) は既に動的対応済み
- ヘッダーコンポーネント (`src/components/navigation/Header.astro`) は`resolveUrl()`を使用

## 技術詳細

ヘッダーナビゲーションは以下の仕組みで動的URL解決を行う：
1. GitHub Action が `BASE_URL` 環境変数を設定
2. Astro が環境変数からベースパスを取得
3. `resolveUrl()` 関数が `import.meta.env.BASE_URL` を使用してパス解決
4. ヘッダーコンポーネントが正しいプロジェクト固有のパスを生成

Closes #232

🤖 Generated with [Claude Code](https://claude.ai/code)