### PR TITLE
feat: Phase 2-3 ブラウザ通知機能の実装

### DIFF
--- a/src/components/Settings.astro
+++ b/src/components/Settings.astro
@@ -236,6 +236,154 @@ const headerID = `${settingsId}-header`;
             <div class="toggle-switch-sm"></div>
           </label>
         </div>
+
+        <!-- Browser Notifications Section -->
+        <div class="notification-subsetting border-t border-soft pt-4 mt-4">
+          <h4 class="text-body font-semibold text-heading mb-3">🔔 ブラウザ通知</h4>
+
+          <!-- Browser Notifications Toggle -->
+          <div class="flex items-center justify-between py-2">
+            <div class="flex-1 space-stack-xs">
+              <label class="text-body font-medium text-heading" for="browser-notifications-enabled">
+                ネイティブ通知
+              </label>
+              <p class="text-body-small text-muted">
+                ブラウザのネイティブ通知システムを使用します（許可が必要）
+              </p>
+            </div>
+
+            <label class="relative inline-flex items-center cursor-pointer ml-4">
+              <input
+                type="checkbox"
+                id="browser-notifications-enabled"
+                class="sr-only peer"
+                data-setting="notifications.browser.enabled"
+              />
+              <div class="toggle-switch-sm"></div>
+            </label>
+          </div>
+
+          <!-- Browser notification subsettings -->
+          <div
+            class="browser-notification-subsetting ml-4 pl-4 border-l-2 border-gray-200 dark:border-gray-700 space-stack-sm"
+          >
+            <!-- Permission Info -->
+            <div
+              class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3"
+            >
+              <div class="flex items-start space-x-2">
+                <svg
+                  class="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                    clip-rule="evenodd"></path>
+                </svg>
+                <div class="flex-1">
+                  <p class="text-body-small font-medium text-blue-800 dark:text-blue-200">
+                    通知許可状態: <span id="notification-permission-status" class="font-mono"
+                      >確認中...</span
+                    >
+                  </p>
+                  <button
+                    type="button"
+                    id="request-notification-permission"
+                    class="mt-2 text-body-small text-blue-600 dark:text-blue-400 underline hover:no-underline"
+                    style="display: none;"
+                  >
+                    通知を許可する
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Auto Request Permission -->
+            <div class="flex items-center justify-between py-2">
+              <div class="flex-1">
+                <label class="text-body font-medium text-heading" for="auto-request-permission">
+                  自動許可リクエスト
+                </label>
+                <p class="text-body-small text-muted">
+                  ブラウザ通知を有効にした際に自動で許可をリクエストします
+                </p>
+              </div>
+
+              <label class="relative inline-flex items-center cursor-pointer ml-4">
+                <input
+                  type="checkbox"
+                  id="auto-request-permission"
+                  class="sr-only peer"
+                  data-setting="notifications.browser.autoRequestPermission"
+                />
+                <div class="toggle-switch-sm"></div>
+              </label>
+            </div>
+
+            <!-- Only When Hidden -->
+            <div class="flex items-center justify-between py-2">
+              <div class="flex-1">
+                <label class="text-body font-medium text-heading" for="only-when-hidden">
+                  非表示時のみ通知
+                </label>
+                <p class="text-body-small text-muted">
+                  ページが非表示の時のみブラウザ通知を表示します
+                </p>
+              </div>
+
+              <label class="relative inline-flex items-center cursor-pointer ml-4">
+                <input
+                  type="checkbox"
+                  id="only-when-hidden"
+                  class="sr-only peer"
+                  data-setting="notifications.browser.onlyWhenHidden"
+                />
+                <div class="toggle-switch-sm"></div>
+              </label>
+            </div>
+
+            <!-- Max Concurrent -->
+            <div>
+              <label class="label" for="max-concurrent-notifications">同時表示数</label>
+              <select
+                id="max-concurrent-notifications"
+                class="input w-full"
+                data-setting="notifications.browser.maxConcurrent"
+              >
+                <option value="1">1個</option>
+                <option value="2">2個</option>
+                <option value="3">3個</option>
+                <option value="5">5個</option>
+                <option value="10">10個</option>
+              </select>
+            </div>
+
+            <!-- Test Browser Notification -->
+            <div class="pt-2">
+              <button
+                type="button"
+                id="test-browser-notification"
+                class="btn btn-outline btn-sm w-full"
+              >
+                <svg
+                  class="icon icon-sm mr-2"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M15 17h5l-5 5-5-5h5v-6H5l5-5 5 5h-5v6z"></path>
+                </svg>
+                テスト通知を送信
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -488,6 +636,7 @@ const headerID = `${settingsId}-header`;
   let settingsManager: UserSettingsManager | null = null;
   let settingsPanel: HTMLElement | null = null;
   let backdrop: HTMLElement | null = null;
+  let browserNotificationManager: any = null;
 
   document.addEventListener('DOMContentLoaded', () => {
     initializeSettings();
@@ -520,6 +669,16 @@ const headerID = `${settingsId}-header`;
       // Dynamically import settings manager
       const { createSettingsManager } = await import('../lib/settings');
       settingsManager = createSettingsManager();
+
+      // Dynamically import browser notification manager
+      const { createBrowserNotificationManager } = await import('../lib/notifications');
+      const settings = settingsManager.getSettings();
+      browserNotificationManager = createBrowserNotificationManager({
+        enabled: settings.notifications.browser.enabled,
+        autoRequestPermission: settings.notifications.browser.autoRequestPermission,
+        onlyWhenHidden: settings.notifications.browser.onlyWhenHidden,
+        maxConcurrent: settings.notifications.browser.maxConcurrent,
+      });
     } catch (error) {
       console.error('Failed to load settings manager:', error);
     }
@@ -535,6 +694,18 @@ const headerID = `${settingsId}-header`;
     setSelectValue('notification-position', settings.notifications.position);
     setSelectValue('notification-animation', settings.notifications.animation);
     setCheckboxValue('show-version-details', settings.notifications.showVersionDetails);
+
+    // Load browser notification settings
+    setCheckboxValue('browser-notifications-enabled', settings.notifications.browser.enabled);
+    setCheckboxValue(
+      'auto-request-permission',
+      settings.notifications.browser.autoRequestPermission
+    );
+    setCheckboxValue('only-when-hidden', settings.notifications.browser.onlyWhenHidden);
+    setSelectValue(
+      'max-concurrent-notifications',
+      String(settings.notifications.browser.maxConcurrent)
+    );
 
     // Load version check settings
     setCheckboxValue('version-check-enabled', settings.versionCheck.enabled);
@@ -552,6 +723,9 @@ const headerID = `${settingsId}-header`;
 
     // Update subsetting visibility
     updateSubsettingVisibility();
+
+    // Update browser notification permission status
+    updateBrowserNotificationStatus();
   }
 
   function setupEventListeners() {
@@ -586,6 +760,13 @@ const headerID = `${settingsId}-header`;
         closeSettings();
       }
     });
+
+    // Browser notification specific events
+    const permissionButton = settingsPanel.querySelector('#request-notification-permission');
+    permissionButton?.addEventListener('click', requestNotificationPermission);
+
+    const testButton = settingsPanel.querySelector('#test-browser-notification');
+    testButton?.addEventListener('click', testBrowserNotification);
   }
 
   function handleSettingChange(event: Event) {
@@ -603,10 +784,40 @@ const headerID = `${settingsId}-header`;
           ? Number(target.value)
           : target.value;
 
-    const [section, key] = settingPath.split('.');
+    const pathParts = settingPath.split('.');
+    const [section, subsection, key] = pathParts;
 
     if (section === 'notifications') {
-      settingsManager.updateNotificationSettings({ [key as keyof NotificationSettings]: value });
+      if (subsection === 'browser') {
+        // Handle nested browser notification settings
+        const currentSettings = settingsManager.getNotificationSettings();
+        settingsManager.updateNotificationSettings({
+          browser: {
+            ...currentSettings.browser,
+            [key as keyof typeof currentSettings.browser]: value,
+          },
+        });
+
+        // Update browser notification manager
+        if (browserNotificationManager) {
+          const browserConfig = settingsManager.getNotificationSettings().browser;
+          browserNotificationManager.updateConfig({
+            enabled: browserConfig.enabled,
+            autoRequestPermission: browserConfig.autoRequestPermission,
+            onlyWhenHidden: browserConfig.onlyWhenHidden,
+            maxConcurrent: browserConfig.maxConcurrent,
+          });
+
+          // Request permission if auto-request is enabled and notifications are enabled
+          if (key === 'enabled' && value && browserConfig.autoRequestPermission) {
+            requestNotificationPermission();
+          }
+        }
+      } else {
+        settingsManager.updateNotificationSettings({
+          [subsection as keyof NotificationSettings]: value,
+        });
+      }
     } else if (section === 'versionCheck') {
       settingsManager.updateVersionCheckSettings({ [key as keyof VersionCheckSettings]: value });
     } else if (section === 'ui') {
@@ -651,6 +862,15 @@ const headerID = `${settingsId}-header`;
     const notificationSubsettings = settingsPanel?.querySelectorAll('.notification-subsetting');
     notificationSubsettings?.forEach(element => {
       (element as HTMLElement).style.display = notificationsEnabled ? 'block' : 'none';
+    });
+
+    // Show/hide browser notification subsettings
+    const browserNotificationsEnabled = getCheckboxValue('browser-notifications-enabled');
+    const browserNotificationSubsettings = settingsPanel?.querySelectorAll(
+      '.browser-notification-subsetting'
+    );
+    browserNotificationSubsettings?.forEach(element => {
+      (element as HTMLElement).style.display = browserNotificationsEnabled ? 'block' : 'none';
     });
 
     // Show/hide version check subsettings
@@ -790,6 +1010,82 @@ const headerID = `${settingsId}-header`;
   function getCheckboxValue(id: string): boolean {
     const checkbox = document.getElementById(id) as HTMLInputElement;
     return checkbox ? checkbox.checked : false;
+  }
+
+  // Browser notification functions
+  function updateBrowserNotificationStatus() {
+    if (!browserNotificationManager) return;
+
+    const statusElement = document.getElementById('notification-permission-status');
+    const requestButton = document.getElementById('request-notification-permission');
+
+    if (!statusElement || !requestButton) return;
+
+    const permission = browserNotificationManager.getPermissionState();
+    const supportInfo = browserNotificationManager.getSupportInfo();
+
+    let statusText = '';
+    let showRequestButton = false;
+
+    if (!supportInfo.supported) {
+      statusText = '未対応';
+    } else {
+      switch (permission) {
+        case 'granted':
+          statusText = '許可済み';
+          break;
+        case 'denied':
+          statusText = 'ブロック中';
+          break;
+        case 'default':
+          statusText = '未許可';
+          showRequestButton = true;
+          break;
+      }
+    }
+
+    statusElement.textContent = statusText;
+    requestButton.style.display = showRequestButton ? 'inline' : 'none';
+  }
+
+  async function requestNotificationPermission() {
+    if (!browserNotificationManager) return;
+
+    try {
+      const permission = await browserNotificationManager.requestPermission();
+      updateBrowserNotificationStatus();
+
+      if (permission === 'granted') {
+        console.log('🔔 Browser notification permission granted');
+      } else {
+        console.warn('🔔 Browser notification permission denied');
+      }
+    } catch (error) {
+      console.error('Failed to request notification permission:', error);
+    }
+  }
+
+  async function testBrowserNotification() {
+    if (!browserNotificationManager) return;
+
+    try {
+      const result = await browserNotificationManager.show({
+        title: 'Beaver Astro Edition',
+        body: 'これはテスト通知です。ブラウザ通知が正常に動作しています！',
+        icon: '/beaver/favicon.png',
+        tag: 'test-notification',
+        requireInteraction: false,
+        autoClose: 5000,
+      });
+
+      if (result.success) {
+        console.log('🔔 Test browser notification sent successfully');
+      } else {
+        console.warn('🔔 Test browser notification fallback:', result.fallback);
+      }
+    } catch (error) {
+      console.error('Failed to send test notification:', error);
+    }
   }
 
   // Expose functions globally for external use

--- a/src/components/layouts/PageLayout.astro
+++ b/src/components/layouts/PageLayout.astro
@@ -321,9 +321,18 @@ const bodyClasses = `min-h-screen flex flex-col antialiased transition-colors du
           const { createSettingsManager } = await import('../../lib/settings.js');
           const settingsManager = createSettingsManager();
 
+          // Initialize browser notification manager
+          const { createBrowserNotificationManager } = await import('../../lib/notifications.js');
+          const settings = settingsManager.getSettings();
+          const browserNotificationManager = createBrowserNotificationManager({
+            enabled: settings.notifications.browser.enabled,
+            autoRequestPermission: settings.notifications.browser.autoRequestPermission,
+            onlyWhenHidden: settings.notifications.browser.onlyWhenHidden,
+            maxConcurrent: settings.notifications.browser.maxConcurrent,
+          });
+
           // Initialize version checker with settings
           const { createVersionChecker } = await import('../../lib/version-checker.js');
-          const settings = settingsManager.getSettings();
 
           const versionChecker = createVersionChecker({
             versionUrl: '/beaver/version.json',
@@ -366,23 +375,67 @@ const bodyClasses = `min-h-screen flex flex-col antialiased transition-colors du
             const notificationSettings = settingsManager.getNotificationSettings();
 
             if (notificationSettings.enabled) {
-              // Show update notification
-              const updateNotification = document.querySelector(
-                '[data-component="update-notification"]'
-              );
-              if (updateNotification) {
-                const showEvent = new CustomEvent('notification:show', {
-                  detail: {
-                    currentVersion: customEvent.detail.currentVersion,
-                    latestVersion: customEvent.detail.latestVersion,
-                    position: notificationSettings.position,
-                    animation: notificationSettings.animation,
-                    showVersionDetails: notificationSettings.showVersionDetails,
-                    autoHide: notificationSettings.autoHide,
-                  },
-                });
-                updateNotification.dispatchEvent(showEvent);
+              // Try browser notification first if enabled
+              if (notificationSettings.browser.enabled && browserNotificationManager) {
+                browserNotificationManager
+                  .show({
+                    title: '新しいバージョンが利用可能です',
+                    body: `Beaver Astro Editionの新しいバージョン ${customEvent.detail.latestVersion?.version || ''} が利用可能になりました。`,
+                    icon: '/beaver/favicon.png',
+                    tag: 'version-update',
+                    requireInteraction: false,
+                    autoClose: 10000,
+                    data: {
+                      currentVersion: customEvent.detail.currentVersion,
+                      latestVersion: customEvent.detail.latestVersion,
+                    },
+                  })
+                  .then(result => {
+                    // If browser notification failed, fall back to in-page notification
+                    if (!result.success) {
+                      showInPageNotification(customEvent, notificationSettings);
+                    }
+                  });
+              } else {
+                // Show in-page notification directly
+                showInPageNotification(customEvent, notificationSettings);
               }
+            }
+          });
+
+          function showInPageNotification(customEvent: CustomEvent, notificationSettings: any) {
+            const updateNotification = document.querySelector(
+              '[data-component="update-notification"]'
+            );
+            if (updateNotification) {
+              const showEvent = new CustomEvent('notification:show', {
+                detail: {
+                  currentVersion: customEvent.detail.currentVersion,
+                  latestVersion: customEvent.detail.latestVersion,
+                  position: notificationSettings.position,
+                  animation: notificationSettings.animation,
+                  showVersionDetails: notificationSettings.showVersionDetails,
+                  autoHide: notificationSettings.autoHide,
+                },
+              });
+              updateNotification.dispatchEvent(showEvent);
+            }
+          }
+
+          // Listen for browser notification fallback events
+          document.addEventListener('browserNotification:fallback', (e: Event) => {
+            const customEvent = e as CustomEvent;
+            const { options, reason } = customEvent.detail;
+
+            console.warn('Browser notification fallback triggered:', reason);
+
+            // If this was a version update notification, show in-page notification
+            if (options.tag === 'version-update' && options.data) {
+              const notificationSettings = settingsManager.getNotificationSettings();
+              const mockEvent = new CustomEvent('version:update-available', {
+                detail: options.data,
+              });
+              showInPageNotification(mockEvent, notificationSettings);
             }
           });
 
@@ -401,6 +454,7 @@ const bodyClasses = `min-h-screen flex flex-col antialiased transition-colors du
           (window as any).beaverSystems = {
             settingsManager,
             versionChecker,
+            browserNotificationManager,
             openSettings: () => {
               const settingsEvent = new CustomEvent('settings:open');
               document.dispatchEvent(settingsEvent);
@@ -408,6 +462,15 @@ const bodyClasses = `min-h-screen flex flex-col antialiased transition-colors du
             checkVersion: () => versionChecker.checkVersion(),
             toggleNotifications: () => settingsManager.toggleNotifications(),
             toggleVersionCheck: () => settingsManager.toggleVersionCheck(),
+            testBrowserNotification: () =>
+              browserNotificationManager?.show({
+                title: 'Beaver Test Notification',
+                body: 'Browser notification system is working correctly!',
+                icon: '/beaver/favicon.png',
+                tag: 'test',
+                requireInteraction: false,
+                autoClose: 5000,
+              }),
           };
 
           console.log('🔄 User systems integration initialized successfully');

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,640 @@
+/**
+ * Browser Notifications Module
+ *
+ * Provides native browser notification functionality that integrates with
+ * the existing user settings system. Supports permission management,
+ * fallback handling, and seamless integration with in-page notifications.
+ *
+ * @module BrowserNotifications
+ */
+
+import { z } from 'zod';
+
+// Browser notification schemas
+export const BrowserNotificationOptionsSchema = z.object({
+  /** Notification title */
+  title: z.string().min(1),
+  /** Notification body text */
+  body: z.string().optional(),
+  /** Notification icon URL */
+  icon: z.string().url().optional(),
+  /** Notification badge URL */
+  badge: z.string().url().optional(),
+  /** Notification tag for grouping */
+  tag: z.string().optional(),
+  /** Whether to require user interaction to dismiss */
+  requireInteraction: z.boolean().default(false),
+  /** Auto-close after milliseconds (0 = never) */
+  autoClose: z.number().int().min(0).default(0),
+  /** Custom data to attach to notification */
+  data: z.record(z.string(), z.any()).optional(),
+  /** Actions to show on notification */
+  actions: z
+    .array(
+      z.object({
+        action: z.string(),
+        title: z.string(),
+        icon: z.string().url().optional(),
+      })
+    )
+    .optional(),
+});
+
+export const BrowserNotificationConfigSchema = z.object({
+  /** Enable browser notifications */
+  enabled: z.boolean().default(false),
+  /** Request permission automatically */
+  autoRequestPermission: z.boolean().default(false),
+  /** Default icon for notifications */
+  defaultIcon: z.string().url().optional(),
+  /** Default badge for notifications */
+  defaultBadge: z.string().url().optional(),
+  /** Maximum number of concurrent notifications */
+  maxConcurrent: z.number().int().min(1).max(10).default(3),
+  /** Show browser notifications only when page is hidden */
+  onlyWhenHidden: z.boolean().default(true),
+});
+
+export const NotificationPermissionStateSchema = z.enum(['default', 'granted', 'denied']);
+
+// Infer TypeScript types
+export type BrowserNotificationOptions = z.infer<typeof BrowserNotificationOptionsSchema>;
+export type BrowserNotificationConfig = z.infer<typeof BrowserNotificationConfigSchema>;
+export type NotificationPermissionState = z.infer<typeof NotificationPermissionStateSchema>;
+
+// Constants
+export const BROWSER_NOTIFICATION_CONSTANTS = {
+  STORAGE_KEY: 'beaver_browser_notifications_config',
+  DEFAULT_ICON: '/beaver/favicon.png',
+  DEFAULT_BADGE: '/beaver/favicon.png',
+  EVENTS: {
+    PERMISSION_CHANGED: 'browserNotification:permission-changed',
+    NOTIFICATION_SHOWN: 'browserNotification:shown',
+    NOTIFICATION_CLICKED: 'browserNotification:clicked',
+    NOTIFICATION_CLOSED: 'browserNotification:closed',
+    NOTIFICATION_ERROR: 'browserNotification:error',
+  } as const,
+  FALLBACK_METHODS: {
+    IN_PAGE: 'in-page',
+    CONSOLE: 'console',
+    NONE: 'none',
+  } as const,
+} as const;
+
+/**
+ * Browser Notification Manager Class
+ *
+ * Manages native browser notifications with permission handling,
+ * fallback support, and integration with user settings.
+ */
+export class BrowserNotificationManager {
+  private config: BrowserNotificationConfig;
+  private eventTarget: EventTarget;
+  private activeNotifications: Map<string, Notification> = new Map();
+  private isSupported: boolean;
+
+  constructor(config: Partial<BrowserNotificationConfig> = {}) {
+    this.eventTarget = new EventTarget();
+    this.isSupported = this.checkBrowserSupport();
+    this.config = BrowserNotificationConfigSchema.parse({
+      ...this.getDefaultConfig(),
+      ...config,
+    });
+
+    // Load saved configuration
+    this.loadConfig();
+
+    // Set up event listeners
+    this.setupEventListeners();
+  }
+
+  /**
+   * Check if browser supports notifications
+   */
+  private checkBrowserSupport(): boolean {
+    return typeof window !== 'undefined' && 'Notification' in window;
+  }
+
+  /**
+   * Get default configuration
+   */
+  private getDefaultConfig(): BrowserNotificationConfig {
+    return {
+      enabled: false,
+      autoRequestPermission: false,
+      defaultIcon: BROWSER_NOTIFICATION_CONSTANTS.DEFAULT_ICON,
+      defaultBadge: BROWSER_NOTIFICATION_CONSTANTS.DEFAULT_BADGE,
+      maxConcurrent: 3,
+      onlyWhenHidden: true,
+    };
+  }
+
+  /**
+   * Load configuration from localStorage
+   */
+  private loadConfig(): void {
+    if (typeof localStorage === 'undefined') return;
+
+    try {
+      const stored = localStorage.getItem(BROWSER_NOTIFICATION_CONSTANTS.STORAGE_KEY);
+      if (stored) {
+        const data = JSON.parse(stored);
+        const validationResult = BrowserNotificationConfigSchema.safeParse(data);
+        if (validationResult.success) {
+          this.config = { ...this.config, ...validationResult.data };
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to load browser notification config:', error);
+    }
+  }
+
+  /**
+   * Save configuration to localStorage
+   */
+  private saveConfig(): void {
+    if (typeof localStorage === 'undefined') return;
+
+    try {
+      localStorage.setItem(BROWSER_NOTIFICATION_CONSTANTS.STORAGE_KEY, JSON.stringify(this.config));
+    } catch (error) {
+      console.warn('Failed to save browser notification config:', error);
+    }
+  }
+
+  /**
+   * Setup event listeners
+   */
+  private setupEventListeners(): void {
+    // Listen for permission changes
+    if (this.isSupported && 'permissions' in navigator) {
+      navigator.permissions
+        .query({ name: 'notifications' as PermissionName })
+        .then(permissionStatus => {
+          permissionStatus.addEventListener('change', () => {
+            this.dispatchEvent(BROWSER_NOTIFICATION_CONSTANTS.EVENTS.PERMISSION_CHANGED, {
+              permission: Notification.permission,
+            });
+          });
+        })
+        .catch(() => {
+          // Permissions API not fully supported, ignore
+        });
+    }
+
+    // Listen for page visibility changes
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+          // Close all active notifications when page becomes visible
+          if (this.config.onlyWhenHidden) {
+            this.closeAll();
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Get current permission state
+   */
+  public getPermissionState(): NotificationPermissionState {
+    if (!this.isSupported) return 'denied';
+    return Notification.permission as NotificationPermissionState;
+  }
+
+  /**
+   * Request notification permission
+   */
+  public async requestPermission(): Promise<NotificationPermissionState> {
+    if (!this.isSupported) {
+      console.warn('Browser notifications are not supported');
+      return 'denied';
+    }
+
+    try {
+      const permission = await Notification.requestPermission();
+      this.dispatchEvent(BROWSER_NOTIFICATION_CONSTANTS.EVENTS.PERMISSION_CHANGED, {
+        permission,
+      });
+      return permission as NotificationPermissionState;
+    } catch (error) {
+      console.error('Failed to request notification permission:', error);
+      return 'denied';
+    }
+  }
+
+  /**
+   * Check if notifications can be shown
+   */
+  private canShowNotification(): { allowed: boolean; reason?: string } {
+    if (!this.config.enabled) {
+      return { allowed: false, reason: 'Browser notifications disabled in settings' };
+    }
+
+    if (!this.isSupported) {
+      return { allowed: false, reason: 'Browser does not support notifications' };
+    }
+
+    if (Notification.permission !== 'granted') {
+      return { allowed: false, reason: 'Notification permission not granted' };
+    }
+
+    if (this.config.onlyWhenHidden && !document.hidden) {
+      return { allowed: false, reason: 'Page is visible and onlyWhenHidden is enabled' };
+    }
+
+    if (this.activeNotifications.size >= this.config.maxConcurrent) {
+      return { allowed: false, reason: 'Maximum concurrent notifications reached' };
+    }
+
+    return { allowed: true };
+  }
+
+  /**
+   * Show a browser notification
+   */
+  public async show(options: BrowserNotificationOptions): Promise<{
+    success: boolean;
+    notification?: Notification;
+    fallback?: string;
+    error?: string;
+  }> {
+    try {
+      // Validate options
+      const validatedOptions = BrowserNotificationOptionsSchema.parse(options);
+
+      // Check if notification can be shown
+      const canShow = this.canShowNotification();
+      if (!canShow.allowed) {
+        return this.handleFallback(validatedOptions, canShow.reason);
+      }
+
+      // Create notification options
+      const notificationOptions: NotificationOptions = {
+        body: validatedOptions.body,
+        icon: validatedOptions.icon || this.config.defaultIcon,
+        badge: validatedOptions.badge || this.config.defaultBadge,
+        tag: validatedOptions.tag,
+        requireInteraction: validatedOptions.requireInteraction,
+        data: validatedOptions.data,
+      };
+
+      // Create and show notification
+      const notification = new Notification(validatedOptions.title, notificationOptions);
+
+      // Generate unique ID for tracking
+      const notificationId = validatedOptions.tag || `notification-${Date.now()}-${Math.random()}`;
+
+      // Store active notification
+      this.activeNotifications.set(notificationId, notification);
+
+      // Set up event handlers
+      notification.addEventListener('show', () => {
+        this.dispatchEvent(BROWSER_NOTIFICATION_CONSTANTS.EVENTS.NOTIFICATION_SHOWN, {
+          id: notificationId,
+          title: validatedOptions.title,
+          options: validatedOptions,
+        });
+      });
+
+      notification.addEventListener('click', () => {
+        this.dispatchEvent(BROWSER_NOTIFICATION_CONSTANTS.EVENTS.NOTIFICATION_CLICKED, {
+          id: notificationId,
+          title: validatedOptions.title,
+          data: validatedOptions.data,
+        });
+
+        // Focus window when notification is clicked
+        if (typeof window !== 'undefined') {
+          window.focus();
+        }
+
+        // Close notification after click
+        notification.close();
+      });
+
+      notification.addEventListener('close', () => {
+        this.activeNotifications.delete(notificationId);
+        this.dispatchEvent(BROWSER_NOTIFICATION_CONSTANTS.EVENTS.NOTIFICATION_CLOSED, {
+          id: notificationId,
+          title: validatedOptions.title,
+        });
+      });
+
+      notification.addEventListener('error', event => {
+        this.activeNotifications.delete(notificationId);
+        this.dispatchEvent(BROWSER_NOTIFICATION_CONSTANTS.EVENTS.NOTIFICATION_ERROR, {
+          id: notificationId,
+          title: validatedOptions.title,
+          error: event,
+        });
+      });
+
+      // Auto-close if configured
+      if (validatedOptions.autoClose > 0) {
+        setTimeout(() => {
+          if (this.activeNotifications.has(notificationId)) {
+            notification.close();
+          }
+        }, validatedOptions.autoClose);
+      }
+
+      return { success: true, notification };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error('Failed to show browser notification:', error);
+      return this.handleFallback(options, errorMessage);
+    }
+  }
+
+  /**
+   * Handle fallback when browser notification cannot be shown
+   */
+  private handleFallback(
+    options: BrowserNotificationOptions,
+    reason?: string
+  ): { success: boolean; fallback: string; error?: string } {
+    console.warn('Browser notification fallback triggered:', reason);
+
+    // Try to dispatch custom event for in-page notification fallback
+    if (typeof document !== 'undefined') {
+      const fallbackEvent = new CustomEvent('browserNotification:fallback', {
+        detail: {
+          options,
+          reason,
+          timestamp: Date.now(),
+        },
+      });
+      document.dispatchEvent(fallbackEvent);
+      return {
+        success: false,
+        fallback: BROWSER_NOTIFICATION_CONSTANTS.FALLBACK_METHODS.IN_PAGE,
+        error: reason,
+      };
+    }
+
+    // Console fallback
+    console.info(`📢 Notification: ${options.title}${options.body ? ` - ${options.body}` : ''}`);
+    return {
+      success: false,
+      fallback: BROWSER_NOTIFICATION_CONSTANTS.FALLBACK_METHODS.CONSOLE,
+      error: reason,
+    };
+  }
+
+  /**
+   * Close a specific notification
+   */
+  public close(notificationId: string): boolean {
+    const notification = this.activeNotifications.get(notificationId);
+    if (notification) {
+      notification.close();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Close all active notifications
+   */
+  public closeAll(): number {
+    const count = this.activeNotifications.size;
+    this.activeNotifications.forEach(notification => notification.close());
+    this.activeNotifications.clear();
+    return count;
+  }
+
+  /**
+   * Update configuration
+   */
+  public updateConfig(newConfig: Partial<BrowserNotificationConfig>): void {
+    this.config = BrowserNotificationConfigSchema.parse({
+      ...this.config,
+      ...newConfig,
+    });
+    this.saveConfig();
+
+    // If notifications were disabled, close all active ones
+    if (!this.config.enabled) {
+      this.closeAll();
+    }
+  }
+
+  /**
+   * Get current configuration
+   */
+  public getConfig(): Readonly<BrowserNotificationConfig> {
+    return { ...this.config };
+  }
+
+  /**
+   * Get browser support information
+   */
+  public getSupportInfo(): {
+    supported: boolean;
+    permission: NotificationPermissionState;
+    maxActions: number;
+    features: {
+      actions: boolean;
+      badge: boolean;
+      image: boolean;
+      renotify: boolean;
+      requireInteraction: boolean;
+      silent: boolean;
+      tag: boolean;
+      timestamp: boolean;
+    };
+  } {
+    if (!this.isSupported) {
+      return {
+        supported: false,
+        permission: 'denied',
+        maxActions: 0,
+        features: {
+          actions: false,
+          badge: false,
+          image: false,
+          renotify: false,
+          requireInteraction: false,
+          silent: false,
+          tag: false,
+          timestamp: false,
+        },
+      };
+    }
+
+    // Check feature support
+    const testNotification = new Notification('test', { silent: true });
+    testNotification.close();
+
+    return {
+      supported: true,
+      permission: this.getPermissionState(),
+      maxActions: (Notification as any).maxActions || 2,
+      features: {
+        actions: 'actions' in Notification.prototype,
+        badge: 'badge' in Notification.prototype,
+        image: 'image' in Notification.prototype,
+        renotify: 'renotify' in Notification.prototype,
+        requireInteraction: 'requireInteraction' in Notification.prototype,
+        silent: 'silent' in Notification.prototype,
+        tag: 'tag' in Notification.prototype,
+        timestamp: 'timestamp' in Notification.prototype,
+      },
+    };
+  }
+
+  /**
+   * Dispatch custom events
+   */
+  private dispatchEvent(type: string, detail: any): void {
+    const event = new CustomEvent(type, { detail });
+    this.eventTarget.dispatchEvent(event);
+
+    // Also dispatch to global document for component listening
+    if (typeof document !== 'undefined') {
+      document.dispatchEvent(event);
+    }
+  }
+
+  /**
+   * Add event listener for notification events
+   */
+  public addEventListener(type: string, listener: EventListener): void {
+    this.eventTarget.addEventListener(type, listener);
+  }
+
+  /**
+   * Remove event listener
+   */
+  public removeEventListener(type: string, listener: EventListener): void {
+    this.eventTarget.removeEventListener(type, listener);
+  }
+
+  /**
+   * Destroy the manager and clean up resources
+   */
+  public destroy(): void {
+    this.closeAll();
+    this.eventTarget.removeEventListener('change', () => {});
+  }
+}
+
+/**
+ * Utility functions for browser notifications
+ */
+export const BrowserNotificationUtils = {
+  /**
+   * Check if browser supports notifications
+   */
+  isSupported(): boolean {
+    return typeof window !== 'undefined' && 'Notification' in window;
+  },
+
+  /**
+   * Check if notifications are currently allowed
+   */
+  isAllowed(): boolean {
+    return BrowserNotificationUtils.isSupported() && Notification.permission === 'granted';
+  },
+
+  /**
+   * Check if permission can be requested
+   */
+  canRequestPermission(): boolean {
+    return BrowserNotificationUtils.isSupported() && Notification.permission === 'default';
+  },
+
+  /**
+   * Create a simple notification
+   */
+  async showSimple(title: string, body?: string, icon?: string): Promise<boolean> {
+    if (!BrowserNotificationUtils.isAllowed()) {
+      return false;
+    }
+
+    try {
+      new Notification(title, { body, icon });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  /**
+   * Request permission with user-friendly handling
+   */
+  async requestPermissionGracefully(): Promise<{
+    granted: boolean;
+    permission: NotificationPermissionState;
+    message?: string;
+  }> {
+    if (!BrowserNotificationUtils.isSupported()) {
+      return {
+        granted: false,
+        permission: 'denied',
+        message: 'このブラウザは通知をサポートしていません',
+      };
+    }
+
+    if (Notification.permission === 'granted') {
+      return {
+        granted: true,
+        permission: 'granted',
+        message: '通知は既に許可されています',
+      };
+    }
+
+    if (Notification.permission === 'denied') {
+      return {
+        granted: false,
+        permission: 'denied',
+        message: '通知がブロックされています。ブラウザの設定から許可してください',
+      };
+    }
+
+    try {
+      const permission = await Notification.requestPermission();
+      return {
+        granted: permission === 'granted',
+        permission: permission as NotificationPermissionState,
+        message: permission === 'granted' ? '通知が許可されました' : '通知が拒否されました',
+      };
+    } catch {
+      return {
+        granted: false,
+        permission: 'denied',
+        message: '通知の許可リクエストに失敗しました',
+      };
+    }
+  },
+};
+
+/**
+ * Singleton instance management
+ */
+let globalBrowserNotificationManager: BrowserNotificationManager | null = null;
+
+export function createBrowserNotificationManager(
+  config?: Partial<BrowserNotificationConfig>
+): BrowserNotificationManager {
+  if (!globalBrowserNotificationManager) {
+    globalBrowserNotificationManager = new BrowserNotificationManager(config);
+  }
+  return globalBrowserNotificationManager;
+}
+
+export function getBrowserNotificationManager(): BrowserNotificationManager | null {
+  return globalBrowserNotificationManager;
+}
+
+export function destroyBrowserNotificationManager(): void {
+  if (globalBrowserNotificationManager) {
+    globalBrowserNotificationManager.destroy();
+    globalBrowserNotificationManager = null;
+  }
+}
+
+// Export default instance creation function
+export default createBrowserNotificationManager;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -27,6 +27,24 @@ export const NotificationSettingsSchema = z.object({
   showVersionDetails: z.boolean().default(true),
   /** Notification sound (future feature) */
   sound: z.boolean().default(false),
+  /** Browser notification settings */
+  browser: z
+    .object({
+      /** Enable native browser notifications */
+      enabled: z.boolean().default(false),
+      /** Request permission automatically */
+      autoRequestPermission: z.boolean().default(false),
+      /** Show browser notifications only when page is hidden */
+      onlyWhenHidden: z.boolean().default(true),
+      /** Maximum concurrent browser notifications */
+      maxConcurrent: z.number().int().min(1).max(10).default(3),
+    })
+    .default({
+      enabled: false,
+      autoRequestPermission: false,
+      onlyWhenHidden: true,
+      maxConcurrent: 3,
+    }),
 });
 
 export const VersionCheckSettingsSchema = z.object({
@@ -100,6 +118,12 @@ export const SETTINGS_CONSTANTS = {
       autoHide: 0,
       showVersionDetails: true,
       sound: false,
+      browser: {
+        enabled: false,
+        autoRequestPermission: false,
+        onlyWhenHidden: true,
+        maxConcurrent: 3,
+      },
     },
     versionCheck: {
       enabled: true,


### PR DESCRIPTION
## 概要

GitHub Issue #271 に対応するブラウザ通知機能の包括的な実装を追加しました。

## 変更内容

### 新機能
- **ネイティブブラウザ通知API統合**: Notification APIを使用したシステム通知
- **権限管理システム**: 通知許可状態の適切な管理（default/granted/denied）
- **フォールバック処理**: 非対応ブラウザでのin-page通知への自動フォールバック
- **設定システム統合**: 既存のユーザー設定との完全統合
- **視認性制御**: ページ非表示時のみ通知表示するオプション
- **同時表示制限**: 最大同時表示数の設定可能

### 技術的改善
- TypeScriptとZodによる完全な型安全性
- イベント駆動アーキテクチャによるコンポーネント間疎結合
- LocalStorageによる設定の永続化
- シングルトンパターンによる状態管理
- CustomEventによる効率的なコンポーネント間通信

### 新規ファイル
- `src/lib/notifications.ts`: ブラウザ通知管理システム

### 変更ファイル
- `src/lib/settings.ts`: ブラウザ通知設定の追加
- `src/components/Settings.astro`: 設定UIとテスト機能の追加
- `src/components/layouts/PageLayout.astro`: システム統合とフォールバック処理

## テスト

- 型チェック、linting、フォーマッティングチェックをすべて通過
- 既存のテストスイートが正常に動作
- ブラウザ通知のテスト機能を設定画面に追加

Closes #271

🤖 Generated with [Claude Code](https://claude.ai/code)