### PR TITLE
feat: 本番環境でのPWAポーリングデバッグログ強制有効化

### DIFF
--- a/src/lib/pwa-init.ts
+++ b/src/lib/pwa-init.ts
@@ -104,8 +104,14 @@ export class PWASystem {
       this.initialized = true;
 
       if (this.config.debug) {
-        console.log('✅ PWA System initialized successfully');
+        console.log('✅ PWA System initialized successfully', {
+          timestamp: new Date().toISOString(),
+          localTime: new Date().toLocaleString('ja-JP'),
+          pollingEnabled: true,
+          debugMode: true,
+        });
         console.log('📊 PWA Status:', this.getStatus());
+        console.log('🔄 PWA Polling logs enabled - watching for version.json requests');
       }
 
       // Dispatch initialization event
@@ -365,7 +371,9 @@ export class PWASystem {
         console.log('🔄 PWA: Polling version.json', {
           url,
           timestamp: new Date().toISOString(),
+          localTime: new Date().toLocaleString('ja-JP'),
           source: 'pwa-polling',
+          requestType: typeof request === 'string' ? 'string' : 'Request object',
         });
 
         try {
@@ -375,10 +383,15 @@ export class PWASystem {
             const versionData = await clonedResponse.json();
             console.log('✅ PWA: Polling response received', {
               status: response.status,
+              statusText: response.statusText,
               fromCache: response.headers.has('cf-cache-status') || response.headers.has('x-cache'),
               version: versionData.version,
               buildId: versionData.buildId,
+              gitCommit: versionData.gitCommit,
+              environment: versionData.environment,
               timestamp: new Date().toISOString(),
+              localTime: new Date().toLocaleString('ja-JP'),
+              responseTime: 'calculated in browser',
             });
           }
           return response;
@@ -401,8 +414,12 @@ export class PWASystem {
         console.log('📊 PWA: Polling status check', {
           initialized: this.initialized,
           serviceWorkerActive: 'serviceWorker' in navigator && navigator.serviceWorker.controller,
+          serviceWorkerReady: navigator.serviceWorker.ready !== undefined,
           timestamp: new Date().toISOString(),
+          localTime: new Date().toLocaleString('ja-JP'),
           checkInterval: this.config.versionCheckInterval,
+          nextCheckIn: `${this.config.versionCheckInterval || 30000}ms`,
+          pwaStatus: 'monitoring',
         });
       }
     }, this.config.versionCheckInterval || 30000);
@@ -503,10 +520,10 @@ if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
   // Initialize after DOM is ready
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
-      initializePWA({ debug: process.env['NODE_ENV'] === 'development' });
+      initializePWA({ debug: true }); // Force debug mode for polling logs
     });
   } else {
-    initializePWA({ debug: process.env['NODE_ENV'] === 'development' });
+    initializePWA({ debug: true }); // Force debug mode for polling logs
   }
 }
 


### PR DESCRIPTION
## 概要

本番環境でもPWAポーリングの動作を完全に可視化するため、デバッグログを強制有効化しました。

## 変更内容

### 本番環境デバッグログ有効化
- PWA初期化時に `debug: true` を強制設定
- 自動初期化でもデバッグモード有効化  
- 環境に関係なくポーリングログが出力される

### ログ詳細化・強化
- **🔄 ポーリング開始ログ**: 日本時間とリクエスト種別追加
- **✅ 成功ログ**: gitCommit、environment、statusText追加
- **📊 ステータスチェックログ**: nextCheckIn、pwaStatus追加
- **初期化ログ**: 詳細なタイムスタンプと設定情報追加

## 出力されるログ例

```javascript
🔄 PWA: Polling version.json {
  url: "https://nyasuto.github.io/beaver/version.json",
  timestamp: "2025-01-13T14:55:30.123Z", 
  localTime: "2025/1/13 23:55:30",
  source: "pwa-polling",
  requestType: "Request object"
}

✅ PWA: Polling response received {
  status: 200,
  statusText: "OK",
  version: "0.1.0",
  buildId: "16250326480",
  gitCommit: "748f753", 
  environment: "production",
  localTime: "2025/1/13 23:55:30"
}

📊 PWA: Polling status check {
  initialized: true,
  serviceWorkerActive: true,
  localTime: "2025/1/13 23:55:30",
  nextCheckIn: "30000ms",
  pwaStatus: "monitoring"
}
```

## テスト

- ✅ 品質チェック通過
- ✅ TypeScript型チェック通過  
- ✅ すべてのテストケース通過

## 効果

これにより本番環境でも：
- PWAポーリングの実行タイミングが可視化
- バージョン取得結果の詳細確認が可能
- システム統合状況のリアルタイム監視
- デバッグ・トラブルシューティングが容易に

🤖 Generated with [Claude Code](https://claude.ai/code)