### PR TITLE
fix: 無効なsite-subdirectoryパラメータを削除

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -34,7 +34,6 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_API_TOKEN }}
           enable-quality-dashboard: true
           deploy-to-pages: true
-          site-subdirectory: beaver
       
       - name: Verify outputs
         run: |


### PR DESCRIPTION
## 概要

Test Beaver Actionで失敗していた無効な `site-subdirectory` パラメータを削除しました。

## 問題

```
Unexpected input(s) 'site-subdirectory', valid inputs are ['github-token', 'codecov-token', 'enable-quality-dashboard', 'deploy-to-pages']
```

- `action.yml` で定義されていない `site-subdirectory` パラメータが `.github/workflows/test-action.yml` で使用されていた
- Beaver Actionのテストが失敗する原因となっていた

## 変更内容

- `.github/workflows/test-action.yml` から `site-subdirectory: beaver` を削除
- Beaver Actionは自動的に適切な `BASE_URL` を設定するため、このパラメータは不要

## テスト

- 品質チェックが通ることを確認
- GitHub Actions テストが正常に動作することを期待

Closes #306 (if applicable)