### PR TITLE
feat: ヘッダーにGitHubリポジトリリンクを追加

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "0.1.0",
-  "timestamp": 1752409231555,
-  "buildId": "local-1752409231555",
-  "gitCommit": "3756608",
+  "timestamp": 1752456371529,
+  "buildId": "local-1752456371529",
+  "gitCommit": "12eac5f",
   "environment": "production",
-  "dataHash": "d973d0a7fff4ed29"
+  "dataHash": "dbe59dbad67ba8ed"
 }

--- a/src/components/navigation/Header.astro
+++ b/src/components/navigation/Header.astro
@@ -7,6 +7,7 @@
  */
 
 import { resolveUrl } from '../../lib/utils/url';
+import { getRepositoryUrls } from '../../lib/github/repository';
 import ThemeToggle from '../ui/ThemeToggle.astro';
 
 export interface Props {
@@ -48,6 +49,9 @@ const isActive = (href: string) => {
   if (href === '/') return currentPath === '/';
   return currentPath.startsWith(href);
 };
+
+// Get GitHub repository URLs
+const githubUrls = getRepositoryUrls();
 
 // Header classes
 const headerClasses = [
@@ -231,6 +235,43 @@ const headerClasses = [
 
       <!-- Right side actions -->
       <div class="flex items-center space-x-2">
+        <!-- GitHub repository links -->
+        <div class="hidden sm:flex items-center space-x-1">
+          <!-- GitHub repository link -->
+          <a
+            href={githubUrls.repository}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="p-2 rounded-md text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-800 transition-colors duration-200 focus-visible"
+            aria-label="GitHubリポジトリを開く"
+            title="GitHubリポジトリ"
+          >
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <path
+                d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+              ></path>
+            </svg>
+          </a>
+
+          <!-- Pull requests link -->
+          <a
+            href={githubUrls.pulls}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="p-2 rounded-md text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-800 transition-colors duration-200 focus-visible"
+            aria-label="Pull Requestsを開く"
+            title="Pull Requests"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
+            </svg>
+          </a>
+        </div>
+
         <!-- Settings button -->
         <button
           id="settings-toggle"
@@ -406,6 +447,45 @@ const headerClasses = [
             </div>
           )
         }
+
+        <!-- GitHub links section for mobile -->
+        <div class="space-y-1 border-t border-gray-200 dark:border-gray-700 pt-3">
+          <div class="px-3 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            GitHub
+          </div>
+          <a
+            href={githubUrls.repository}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="block px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-800 transition-colors duration-200"
+          >
+            <span class="flex items-center space-x-2">
+              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+                ></path>
+              </svg>
+              <span>リポジトリ</span>
+            </span>
+          </a>
+          <a
+            href={githubUrls.pulls}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="block px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-800 transition-colors duration-200"
+          >
+            <span class="flex items-center space-x-2">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
+              </svg>
+              <span>Pull Requests</span>
+            </span>
+          </a>
+        </div>
 
         {
           showSearch && (

--- a/src/lib/github/repository.ts
+++ b/src/lib/github/repository.ts
@@ -211,6 +211,24 @@ export const RepositoryStatsSchema = z.object({
 export type RepositoryStats = z.infer<typeof RepositoryStatsSchema>;
 
 /**
+ * Repository URL utilities
+ */
+export function getRepositoryUrls() {
+  const REPO_OWNER = 'nyasuto';
+  const REPO_NAME = 'beaver';
+  const baseUrl = `https://github.com/${REPO_OWNER}/${REPO_NAME}`;
+
+  return {
+    repository: baseUrl,
+    pulls: `${baseUrl}/pulls`,
+    issues: `${baseUrl}/issues`,
+    commits: `${baseUrl}/commits`,
+    releases: `${baseUrl}/releases`,
+    actions: `${baseUrl}/actions`,
+  };
+}
+
+/**
  * GitHub Repository API Service
  *
  * Provides comprehensive repository management functionality including


### PR DESCRIPTION
## 概要

Issue #313の実装：ヘッダーナビゲーションにGitHubリポジトリとPull Requestsへのリンクを追加しました。これはPR管理機能のPhase 1となります。

## 変更内容

### 🔗 ヘッダーリンク追加
- デスクトップナビゲーションにGitHubリポジトリとPull Requestsのアイコンリンクを追加
- モバイルメニューにGitHub専用セクションを追加し、リポジトリとPull Requestsリンクを配置
- すべてのリンクは新しいタブで開き、適切なsecurity属性（`rel="noopener noreferrer"`）を設定

### 🛠️ 技術的改善
- `src/lib/github/repository.ts`に`getRepositoryUrls()`関数を追加
- リポジトリURLの生成を一元化し、保守性を向上
- TypeScript型安全性を保持

### ♿ アクセシビリティ対応
- 各リンクに適切な`aria-label`と`title`属性を設定
- 日本語のラベル/タイトルでユーザビリティを向上
- フォーカス管理とキーボードナビゲーション対応

### 📱 レスポンシブデザイン
- デスクトップ：右側アクションエリアにアイコンリンク
- モバイル：専用セクションでテキスト付きリンク
- `sm:hidden`/`hidden sm:flex`クラスで適切な表示切り替え

## テスト

- 型チェック: ✅ 通過
- 各種リンター: ✅ 通過  
- ビルドテスト: ✅ 成功
- 全テストスイート: ✅ 1791件通過

## 次のステップ

- Phase 2: GitHub APIを使用したPR情報の表示機能（Issue #314）
- Phase 3: PR詳細表示とレビュー管理機能（Issue #315）
- Phase 4: 完全なワークフロー統合（Issue #316）

Closes #313

🤖 Generated with [Claude Code](https://claude.ai/code)