### PR TITLE
fix: markdownレンダリングでのimport.meta.envエラーを修正

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "0.1.0",
-  "timestamp": 1752457724566,
-  "buildId": "local-1752457724566",
-  "gitCommit": "ad07dbe",
+  "timestamp": 1752460136708,
+  "buildId": "local-1752460136708",
+  "gitCommit": "ebbead7",
   "environment": "production",
-  "dataHash": "9dd1af75cbe69978"
+  "dataHash": "9600c9273ce4989d"
 }

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -86,7 +86,7 @@ export async function markdownToHtml(markdown: string): Promise<string> {
     });
 
     // Debug logging for development
-    if (import.meta.env.DEV) {
+    if (import.meta.env?.DEV) {
       console.log('🔍 Markdown Processing Debug:', {
         inputLength: markdown.length,
         outputLength: sanitizedHtml.length,

--- a/src/pages/issues/[id].astro
+++ b/src/pages/issues/[id].astro
@@ -50,7 +50,7 @@ const description = `Detailed view of GitHub issue #${currentIssue.number} with 
 const processedBody = currentIssue.body ? await markdownToHtml(currentIssue.body) : '';
 
 // デバッグ用：markdown処理結果をコンソールに出力
-if (import.meta.env.DEV && currentIssue.number === 314) {
+if (import.meta.env?.DEV && currentIssue.number === 314) {
   console.log('🔍 Debug Issue #314 Markdown Processing:');
   console.log('Original body length:', currentIssue.body?.length || 0);
   console.log('Processed body length:', processedBody.length);


### PR DESCRIPTION
## 概要

markdownレンダリング処理でのimport.meta.envエラーを修正しました。これによりmarkdownが正しくHTMLとしてレンダリングされるようになります。

## 問題の原因

`import.meta.env.DEV`がNode.js環境（ビルド時）では`undefined`になり、TypeErrorが発生していました：

```
TypeError: Cannot read properties of undefined (reading 'DEV')
```

## 変更内容

### 🔧 環境変数アクセスの修正
- `import.meta.env.DEV` → `import.meta.env?.DEV`
- オプショナルチェーンによりundefinedエラーを防止
- `src/lib/utils/markdown.ts`と`src/pages/issues/[id].astro`の両方を修正

## テスト

✅ **Direct testing confirmed**:
```
Input: ## 🎯 EPIC: 統合PR管理機能の実装
Output: <h2>🎯 EPIC: 統合PR管理機能の実装</h2>
```

✅ **Quality checks**: 1791 tests passed

## 影響

この修正により、Issue詳細ページでmarkdownが正しくHTMLレンダリングされ、見出し、太字、リストなどが適切に表示されるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)