### PR TITLE
fix: Pull Requestsページのデータ表示問題を修正

### DIFF
--- a/scripts/__tests__/fetch-github-data.test.ts
+++ b/scripts/__tests__/fetch-github-data.test.ts
@@ -458,9 +458,17 @@ describe('fetch-github-data スクリプト', () => {
             name: 'test-repo',
           },
           statistics: {
-            total: 2,
-            open: 2,
-            closed: 0,
+            issues: {
+              total: 2,
+              open: 2,
+              closed: 0,
+            },
+            pullRequests: {
+              total: 0,
+              open: 0,
+              closed: 0,
+              merged: 0,
+            },
             labels: 3, // bug, high-priority, feature
           },
           labelCounts: {
@@ -485,9 +493,15 @@ describe('fetch-github-data スクリプト', () => {
       await fetchAndSaveGitHubData();
 
       expect(consoleLogSpy).toHaveBeenCalledWith('📊 統計情報:');
-      expect(consoleLogSpy).toHaveBeenCalledWith('   - 総 Issue 数: 2');
-      expect(consoleLogSpy).toHaveBeenCalledWith('   - オープン: 2');
-      expect(consoleLogSpy).toHaveBeenCalledWith('   - クローズ: 0');
+      expect(consoleLogSpy).toHaveBeenCalledWith('   Issues:');
+      expect(consoleLogSpy).toHaveBeenCalledWith('     - 総数: 2');
+      expect(consoleLogSpy).toHaveBeenCalledWith('     - オープン: 2');
+      expect(consoleLogSpy).toHaveBeenCalledWith('     - クローズ: 0');
+      expect(consoleLogSpy).toHaveBeenCalledWith('   Pull Requests:');
+      expect(consoleLogSpy).toHaveBeenCalledWith('     - 総数: 0');
+      expect(consoleLogSpy).toHaveBeenCalledWith('     - オープン: 0');
+      expect(consoleLogSpy).toHaveBeenCalledWith('     - クローズ: 0');
+      expect(consoleLogSpy).toHaveBeenCalledWith('     - マージ済み: 0');
       expect(consoleLogSpy).toHaveBeenCalledWith('   - ラベル数: 3');
     });
   });

--- a/src/lib/schemas/pulls.ts
+++ b/src/lib/schemas/pulls.ts
@@ -80,7 +80,7 @@ export const PullRequestSchema = z.object({
   head: BranchRefSchema,
   base: BranchRefSchema,
   draft: z.boolean(),
-  mergeable: z.boolean().nullable(),
+  mergeable: z.boolean().nullable().optional(),
   mergeable_state: z.string().optional(),
   merged: z.boolean().optional(),
   merge_commit_sha: z.string().nullable().optional(),

--- a/src/pages/pulls/index.astro
+++ b/src/pages/pulls/index.astro
@@ -3,56 +3,43 @@
  * Pull Requests List Page
  *
  * Displays a comprehensive list of GitHub Pull Requests with filtering and sorting capabilities.
- * Part of Issue #314 - PR管理機能 Phase 2 implementation.
+ * Uses pre-generated static data for optimal performance and GitHub Pages compatibility.
  */
 
 import PageLayout from '../../components/layouts/PageLayout.astro';
-import { GitHubPullsService } from '../../lib/github/pulls';
-import { createGitHubClient } from '../../lib/github/client';
 import { resolveUrl } from '../../lib/utils/url';
 import type { EnhancedPullRequest } from '../../lib/schemas/pulls';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
 
-// Initialize GitHub client and service
+// Load Pull Requests data from static JSON file
 let pulls: EnhancedPullRequest[] = [];
 let error: string | null = null;
 
 try {
-  // Get repository info from environment or configuration
-  const owner = 'nyasuto'; // TODO: Make this configurable
-  const repo = 'beaver'; // TODO: Make this configurable
+  const dataPath = join(process.cwd(), 'src/data/github/pulls.json');
 
-  // Get GitHub token from environment variables (type assertion for Astro env)
-  const githubToken = (import.meta.env as any).GITHUB_TOKEN || '';
+  if (existsSync(dataPath)) {
+    const rawData = readFileSync(dataPath, 'utf-8');
+    const pullsData = JSON.parse(rawData);
 
-  const clientResult = createGitHubClient({
-    token: githubToken,
-    owner,
-    repo,
-  });
-
-  if (!clientResult.success) {
-    error = clientResult.error.message;
-  } else {
-    const pullsService = new GitHubPullsService(clientResult.data);
-
-    // Fetch enhanced pull requests with default parameters
-    const result = await pullsService.fetchEnhancedPullRequests(owner, repo, {
-      state: 'open',
-      sort: 'created',
-      direction: 'desc',
-      per_page: 50,
-      page: 1,
-    });
-
-    if (result.success) {
-      pulls = result.data;
+    // Ensure we have an array of pull requests
+    if (Array.isArray(pullsData)) {
+      pulls = pullsData;
+      console.log(`✅ Loaded ${pulls.length} pull requests from static data`);
     } else {
-      error = result.error.message;
+      console.warn('⚠️ Pull requests data is not an array');
+      pulls = [];
     }
+  } else {
+    console.warn('⚠️ Pull requests data file not found:', dataPath);
+    console.warn('Run "npm run fetch-data" to generate GitHub data');
+    pulls = [];
   }
 } catch (e) {
-  error = e instanceof Error ? e.message : 'Failed to fetch pull requests';
-  console.error('Pull requests fetch error:', e);
+  error = e instanceof Error ? e.message : 'Failed to load pull requests data';
+  console.error('Pull requests data load error:', e);
+  pulls = [];
 }
 
 const title = 'Pull Requests | Beaver';
@@ -115,11 +102,11 @@ const description = 'Manage and track GitHub Pull Requests directly within Beave
       <div class="flex items-center gap-3">
         <span class="text-sm font-medium text-heading">Filter:</span>
         <div class="flex items-center gap-2">
-          <button class="filter-btn active" data-state="open" aria-pressed="true">
+          <button class="filter-btn" data-state="open" aria-pressed="false">
             <span class="w-2 h-2 bg-green-500 rounded-full inline-block mr-2"></span>
             Open
           </button>
-          <button class="filter-btn" data-state="closed" aria-pressed="false">
+          <button class="filter-btn active" data-state="closed" aria-pressed="true">
             <span class="w-2 h-2 bg-red-500 rounded-full inline-block mr-2"></span>
             Closed
           </button>
@@ -448,7 +435,7 @@ const description = 'Manage and track GitHub Pull Requests directly within Beave
     const searchInput = document.getElementById('search-input') as HTMLInputElement;
     const sortSelect = document.getElementById('sort-select') as HTMLSelectElement;
 
-    let currentFilter = 'open';
+    let currentFilter = 'closed';
     let currentSort = 'created';
     let searchQuery = '';
 


### PR DESCRIPTION
## 概要

Pull Requestsページでデータが表示されない問題を修正しました。GitHub Pages環境でのAPI制限に対応し、静的データファイル方式に変更することで100件のPull Requestsを正常に表示できるようになりました。

## 変更内容

### 🔧 **データ取得システムの改善**
- **Pull Requests取得機能追加**: `fetch-github-data.ts`にPull Requestsデータ取得機能を追加
- **静的データ方式への変更**: `pulls/index.astro`を動的API呼び出しから静的データ読み込みに変更
- **スキーマ修正**: `pulls.ts`の`mergeable`フィールドをoptionalに修正してバリデーションエラーを解消

### 🎯 **フィルター初期値の改善**
- **初期フィルター変更**: `open`から`closed`に変更（実際のデータに合わせて表示）
- **UIの改善**: フィルターボタンの初期状態を`closed`に設定

### 📊 **データ処理の最適化**
- **100件のPull Requests取得**: open/closed両方の状態を取得し合計100件のデータを生成
- **個別データファイル**: 各Pull Requestの詳細データを個別JSONファイルとして保存
- **エラーハンドリング強化**: データ読み込み失敗時の適切なエラー表示

## 技術的改善

### GitHub Pages対応
- **APIトークン制限**: ビルド時にGitHubトークンが利用できない問題を解決
- **静的サイト生成**: 事前にデータを取得してJSONファイルとして保存
- **パフォーマンス向上**: 動的API呼び出しを排除してページ読み込み速度を改善

### データ整合性
- **スキーマバリデーション**: Zodスキーマでの型安全性を維持
- **データ品質**: GitHub APIレスポンスの`undefined`値に対応
- **一貫性のある表示**: 既存のIssuesページと同様のデータ構造を採用

## テスト

- **型チェック**: TypeScriptエラーなし ✅
- **リント**: ESLintエラーなし（既存の警告のみ） ✅  
- **フォーマット**: Prettier準拠 ✅
- **ビルド**: 成功 ✅
- **データ読み込み**: 「✅ Loaded 100 pull requests from static data」確認済み ✅

## 影響範囲

### 改善された機能
- Pull Requestsページが正常に100件のデータを表示
- フィルター機能によるclosed/merged Pull Requestsの閲覧
- GitHub Pages環境での安定した動作

### 技術的メリット
- **スケーラビリティ**: 静的データによる高速表示
- **信頼性**: API制限による表示失敗を回避
- **保守性**: 統一されたデータ取得・表示パターン

🤖 Generated with [Claude Code](https://claude.ai/code)