### PR TITLE
fix: Pull Requestsページのデフォルトフィルターをopenに変更

### DIFF
--- a/src/pages/pulls/index.astro
+++ b/src/pages/pulls/index.astro
@@ -139,11 +139,11 @@ const description = 'Manage and track GitHub Pull Requests directly within Beave
       <div class="flex items-center gap-3">
         <span class="text-sm font-medium text-heading">Filter:</span>
         <div class="flex items-center gap-2">
-          <button class="filter-btn" data-state="open" aria-pressed="false">
+          <button class="filter-btn active" data-state="open" aria-pressed="true">
             <span class="w-2 h-2 bg-green-500 rounded-full inline-block mr-2"></span>
             Open
           </button>
-          <button class="filter-btn active" data-state="closed" aria-pressed="true">
+          <button class="filter-btn" data-state="closed" aria-pressed="false">
             <span class="w-2 h-2 bg-red-500 rounded-full inline-block mr-2"></span>
             Closed
           </button>
@@ -451,7 +451,7 @@ const description = 'Manage and track GitHub Pull Requests directly within Beave
     const searchInput = document.getElementById('search-input') as HTMLInputElement;
     const sortSelect = document.getElementById('sort-select') as HTMLSelectElement;
 
-    let currentFilter = 'closed';
+    let currentFilter = 'open';
     let currentSort = 'created';
     let searchQuery = '';
 


### PR DESCRIPTION
## 概要

Pull RequestsページでデフォルトでクローズされたPRが表示される問題を修正しました。

## 変更内容

- デフォルトフィルターを `'closed'` から `'open'` に変更
- Openボタンをデフォルトでアクティブ状態に設定  
- ページ読み込み時にオープンなPRのみが表示されるよう修正

## テスト

- Pull RequestsページがデフォルトでオープンなPRのみを表示することを確認
- フィルターボタンが正しく動作することを確認

Closes #なし（ユーザー報告による修正）