### PR TITLE
fix: Pull Requestsページでページロード時にフィルタリングを実行

### DIFF
--- a/src/pages/pulls/index.astro
+++ b/src/pages/pulls/index.astro
@@ -514,5 +514,8 @@ const description = 'Manage and track GitHub Pull Requests directly within Beave
     refreshButton?.addEventListener('click', () => {
       window.location.reload();
     });
+
+    // Apply initial filter on page load
+    filterPulls();
   });
 </script>


### PR DESCRIPTION
## 概要

Pull Requestsページでページロード時にフィルタリングが実行されない問題を修正しました。

## 問題の詳細

- デフォルトフィルターが`'open'`に設定されているが、ページロード時にフィルタリングが実行されない
- そのため、オープンなPRが0個でもクローズされたPRが表示されてしまう
- 統計情報は正しく「オープン: 0 / クローズ: 4」と表示されている

## 修正内容

- DOMContentLoadedイベントの最後で`filterPulls()`を呼び出し
- ページロード時にデフォルトフィルター(`'open'`)が正しく適用される
- オープンなPRが0個の場合は正しく空の状態を表示

## テスト

- ページロード時にOpenフィルターが選択され、オープンなPRのみが表示されることを確認
- Closedフィルターをクリックした際にクローズされたPRが表示されることを確認

Closes #なし（ユーザー報告による修正）