### PR TITLE
fix: ドキュメントページのタイトル重複を解決

### DIFF
--- a/src/lib/markdown/__tests__/processor.test.ts
+++ b/src/lib/markdown/__tests__/processor.test.ts
@@ -44,9 +44,14 @@ More content.`;
       expect(result.metadata.title).toBe('Test Document');
       expect(result.metadata.description).toBe('A test document');
       expect(result.metadata.tags).toEqual(['test', 'markdown']);
-      expect(result.htmlContent).toContain('<h1>Test Document</h1>');
-      expect(result.htmlContent).toContain('<strong>test</strong>');
-      expect(result.sections).toHaveLength(3); // H1, H2, H3
+      // The first h1 title and its description should be removed to avoid duplication with page header
+      expect(result.htmlContent).not.toContain('<h1>Test Document</h1>');
+      expect(result.htmlContent).not.toContain(
+        'This is a <strong>test</strong> document with some content.'
+      );
+      expect(result.htmlContent).toContain('<h2>Section 1</h2>');
+      expect(result.htmlContent).toContain('Some content here.');
+      expect(result.sections).toHaveLength(3); // H1, H2, H3 (sections are extracted before removal)
     });
 
     it('should extract title from content if not in frontmatter', async () => {


### PR DESCRIPTION
## 概要

ドキュメントページでタイトルと説明文が重複表示される問題を修正しました。
ページヘッダーとMarkdownコンテンツの最初のh1タイトルが重複していた冗長性を解消。

## 変更内容

- **removeFirstH1Title関数を新規実装**: Markdownコンテンツから最初のh1タイトルとその直後の説明文を自動除去
- **processMarkdown関数にタイトル除去ロジックを統合**: HTML変換前に重複タイトルを除去
- **テストの更新**: 新しい動作に合わせてprocessor.test.tsを修正
- **TOC生成機能は維持**: セクション抽出はタイトル除去前に実行するため影響なし

## テスト

- 全テストパス: 2659 passed | 9 skipped
- 品質チェック完了: lint、format、type-check すべて通過
- 新しい動作をテストケースで検証済み

Closes #350

🤖 Generated with [Claude Code](https://claude.ai/code)