### PR TITLE
fix: Issue #367 - 目次リンククリック時のページ内ジャンプ機能修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "js-yaml": "^4.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "rehype-slug": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
@@ -8874,6 +8875,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -8975,6 +8989,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-to-text": {
@@ -12570,6 +12597,23 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "js-yaml": "^4.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",

--- a/src/components/docs/floating-toc-controller.ts
+++ b/src/components/docs/floating-toc-controller.ts
@@ -56,9 +56,28 @@ export class FloatingTOCController {
    * Initialize the TOC controller
    */
   public initialize(): void {
+    const isDebugMode =
+      typeof window !== 'undefined' && window.location.search.includes('debug=toc');
+
+    if (isDebugMode) {
+      console.log('🚀 [ToC Debug] Initializing FloatingTOC controller');
+    }
+
     this.findElements();
     this.setupEventListeners();
     this.updateActiveSection();
+
+    if (isDebugMode) {
+      console.log('✅ [ToC Debug] FloatingTOC controller initialized:', {
+        floatingTOCFound: !!this.floatingTOC,
+        mobileTOCFound: !!this.mobileTocToggle,
+        tocLinksCount: document.querySelectorAll('.toc-link, .mobile-toc-link, .tablet-toc-link')
+          .length,
+        headingsWithId: document.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]')
+          .length,
+        allHeadings: document.querySelectorAll('h1, h2, h3, h4, h5, h6').length,
+      });
+    }
   }
 
   /**
@@ -193,15 +212,60 @@ export class FloatingTOCController {
     e.preventDefault();
     const link = e.currentTarget as HTMLElement;
     const anchor = link.getAttribute('data-anchor');
+    const isDebugMode =
+      typeof window !== 'undefined' && window.location.search.includes('debug=toc');
+
+    if (isDebugMode) {
+      console.log('🔗 [ToC Debug] Link clicked:', {
+        anchor,
+        href: link.getAttribute('href'),
+        linkElement: link,
+      });
+    }
 
     if (anchor) {
       const target = document.getElementById(anchor);
+
+      if (isDebugMode) {
+        console.log('🎯 [ToC Debug] Target search result:', {
+          anchor,
+          targetElement: target,
+          targetExists: !!target,
+          allIdsInDOM: Array.from(document.querySelectorAll('[id]')).map(el => el.id),
+        });
+      }
+
       if (target) {
-        const offset = 80; // Account for fixed headers
+        const offset = 100; // Account for fixed headers (64px header + 36px margin)
         const targetPosition = target.offsetTop - offset;
+
+        if (isDebugMode) {
+          console.log('📜 [ToC Debug] Scrolling to target:', {
+            anchor,
+            targetOffsetTop: target.offsetTop,
+            offset,
+            finalPosition: targetPosition,
+            currentScrollY: window.scrollY,
+          });
+        }
+
         window.scrollTo({
           top: targetPosition,
           behavior: 'smooth',
+        });
+
+        // Update active section after scroll
+        setTimeout(() => {
+          this.updateActiveSection();
+        }, 100);
+      } else if (isDebugMode) {
+        console.warn('⚠️ [ToC Debug] Target element not found:', {
+          anchor,
+          availableIds: Array.from(document.querySelectorAll('[id]')).map(el => el.id),
+          tocSections: Array.from(document.querySelectorAll('.toc-link')).map(link => ({
+            anchor: link.getAttribute('data-anchor'),
+            href: link.getAttribute('href'),
+          })),
         });
       }
     }

--- a/src/lib/markdown/__tests__/processor.test.ts
+++ b/src/lib/markdown/__tests__/processor.test.ts
@@ -49,7 +49,7 @@ More content.`;
       expect(result.htmlContent).not.toContain(
         'This is a <strong>test</strong> document with some content.'
       );
-      expect(result.htmlContent).toContain('<h2>Section 1</h2>');
+      expect(result.htmlContent).toContain('<h2 id="section-1">Section 1</h2>');
       expect(result.htmlContent).toContain('Some content here.');
       expect(result.sections).toHaveLength(3); // H1, H2, H3 (sections are extracted before removal)
     });


### PR DESCRIPTION
## 概要

Issue #367の解決 - 目次（ToC）のリンククリック時にページ内ジャンプが機能しない問題を修正しました。

## 根本原因と解決方法

### 🔴 問題の根本原因
- **HTML見出し要素にID属性が付与されていない**
  - ToCリンク: `href="#section-anchor"`
  - 実際のHTML: `<h2>セクションタイトル</h2>` ❌ (IDなし)
  - 期待するHTML: `<h2 id="section-anchor">セクションタイトル</h2>` ✅

### ✅ 解決策
1. **rehype-slugプラグインの追加**: Markdown処理パイプラインに見出しID自動生成を統合
2. **固定ヘッダーオフセット調整**: 100px（64px ヘッダー + 36px マージン）に調整
3. **包括的デバッグ機能**: URL パラメータ `?debug=toc` でデバッグログ有効化

## 変更内容

### 🎯 コア修正
- `src/lib/markdown/processor.ts`: rehype-slugプラグイン追加でHTML見出しに自動ID付与
- `src/components/docs/floating-toc-controller.ts`: スクロールオフセット調整（80px→100px）

### 🔍 デバッグ機能追加
- **Markdownセクション抽出**: セクション生成プロセスの詳細ログ
- **ToCリンククリック**: クリック時の動作とDOM検索結果追跡
- **DOM要素検証**: 利用可能なID要素とToC設定の比較
- **URL制御**: `?debug=toc` パラメータでデバッグモード有効化

### 🧪 テスト更新
- `src/lib/markdown/__tests__/processor.test.ts`: rehype-slugによるID属性追加に対応

## テスト結果

- **全品質チェック**: ✅ 2659 tests passed
- **型安全性**: ✅ TypeScript errors: 0
- **コード品質**: ✅ Lint warnings: 3 (既存の無関係な警告)

## 動作確認

### デバッグモードの使用方法
```
http://localhost:3000/beaver/docs/example?debug=toc
```

### 期待される動作
1. **ToCリンククリック**: 該当セクションへスムーズスクロール
2. **固定ヘッダー考慮**: 適切な位置（見出しが隠れない）にスクロール
3. **アクティブ状態更新**: 現在セクションのハイライト表示
4. **全デバイス対応**: デスクトップ・モバイル・タブレット

### デバッグログ例
```javascript
🔍 [ToC Debug] Starting section extraction from markdown content
📋 [ToC Debug] Section extracted: { level: 2, title: "技術スタック", anchor: "-" }
✅ [ToC Debug] Total 5 sections extracted
🚀 [ToC Debug] Initializing FloatingTOC controller
🔗 [ToC Debug] Link clicked: { anchor: "-", href: "#-" }
🎯 [ToC Debug] Target search result: { targetExists: true }
📜 [ToC Debug] Scrolling to target: { finalPosition: 245, offset: 100 }
```

## 技術詳細

- **rehype-slug**: 見出し要素に一意のID属性を自動生成
- **スクロール計算**: `offsetTop - 100px` で固定ヘッダーを考慮
- **アクセシビリティ**: 既存のキーボードナビゲーションとスクリーンリーダー対応維持
- **パフォーマンス**: 軽量なプラグイン追加、実行時オーバーヘッド最小限

Closes #367