### PR TITLE
fix: Vitest v4対応 - Octokitモックのクラスベース化 (Issue #492)

### DIFF
--- a/src/lib/github/__tests__/client.test.ts
+++ b/src/lib/github/__tests__/client.test.ts
@@ -9,9 +9,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GitHubClient, type GitHubConfig } from '../client';
 
 // Mock the Octokit constructor
-vi.mock('@octokit/rest', () => ({
-  Octokit: vi.fn().mockImplementation(() => ({
-    rest: {
+vi.mock('@octokit/rest', () => {
+  class MockOctokit {
+    rest = {
       repos: {
         get: vi.fn(),
         listLanguages: vi.fn(),
@@ -26,12 +26,15 @@ vi.mock('@octokit/rest', () => ({
       users: {
         getAuthenticated: vi.fn(),
       },
-    },
-  })),
-}));
+    };
+  }
 
-// TODO: Fix for vitest v4 - Octokit mocking issues
-describe.skip('GitHubClient', () => {
+  return {
+    Octokit: MockOctokit,
+  };
+});
+
+describe('GitHubClient', () => {
   let client: GitHubClient;
   let mockConfig: GitHubConfig;
 

--- a/src/lib/github/__tests__/issues.test.ts
+++ b/src/lib/github/__tests__/issues.test.ts
@@ -11,21 +11,24 @@ import { GitHubClient, type GitHubConfig } from '../client';
 import { createMockGitHubIssue } from '../__mocks__/data';
 
 // Mock the Octokit constructor
-vi.mock('@octokit/rest', () => ({
-  Octokit: vi.fn().mockImplementation(() => ({
-    rest: {
+vi.mock('@octokit/rest', () => {
+  class MockOctokit {
+    rest = {
       issues: {
         listForRepo: vi.fn(),
         get: vi.fn(),
         create: vi.fn(),
         update: vi.fn(),
       },
-    },
-  })),
-}));
+    };
+  }
 
-// TODO: Fix for vitest v4 - Octokit mocking issues
-describe.skip('GitHub Issues API', () => {
+  return {
+    Octokit: MockOctokit,
+  };
+});
+
+describe('GitHub Issues API', () => {
   let mockConfig: GitHubConfig;
   let issuesService: GitHubIssuesService;
   let mockClient: GitHubClient;

--- a/src/lib/github/__tests__/repository.test.ts
+++ b/src/lib/github/__tests__/repository.test.ts
@@ -27,18 +27,24 @@ const mockOctokit = {
 };
 
 // Mock GitHubClient
-vi.mock('../client', () => ({
-  GitHubClient: vi.fn().mockImplementation(() => ({
-    getConfig: vi.fn().mockReturnValue({
-      owner: 'test-owner',
-      repo: 'test-repo',
-      token: 'test-token',
-      baseUrl: 'https://api.github.com',
-      userAgent: 'beaver-astro/1.0.0',
-    }),
-    getOctokit: vi.fn().mockReturnValue(mockOctokit),
-  })),
-  GitHubError: class GitHubError extends Error {
+vi.mock('../client', () => {
+  class MockGitHubClient {
+    getConfig() {
+      return {
+        owner: 'test-owner',
+        repo: 'test-repo',
+        token: 'test-token',
+        baseUrl: 'https://api.github.com',
+        userAgent: 'beaver-astro/1.0.0',
+      };
+    }
+
+    getOctokit() {
+      return mockOctokit;
+    }
+  }
+
+  class GitHubError extends Error {
     constructor(
       message: string,
       public status?: number,
@@ -47,11 +53,15 @@ vi.mock('../client', () => ({
       super(message);
       this.name = 'GitHubError';
     }
-  },
-}));
+  }
 
-// TODO: Fix for vitest v4 - Octokit mocking issues
-describe.skip('GitHubRepositoryService', () => {
+  return {
+    GitHubClient: MockGitHubClient,
+    GitHubError,
+  };
+});
+
+describe('GitHubRepositoryService', () => {
   let service: GitHubRepositoryService;
   let mockClient: GitHubClient;
 


### PR DESCRIPTION
## 概要

Issue #492 対応 - GitHub API関連テストのOctokitモックをvitest v4に対応したクラスベースパターンに変更しました。

## 背景

Vitest v4では、`vi.fn().mockImplementation()`で作成したモックを`new`演算子でコンストラクタとして呼び出すことができなくなりました。そのため、Octokitなどのクラスをモックする際は、実際のクラス定義を使用する必要があります。

## 変更内容

### 修正したファイル

1. **src/lib/github/__tests__/client.test.ts** (29テスト復旧)
   - Octokitモックを関数ベースからクラスベースに変更
   - `describe.skip()`とTODOコメントを削除

2. **src/lib/github/__tests__/issues.test.ts** (10テスト復旧)
   - Octokitモックを関数ベースからクラスベースに変更
   - `describe.skip()`とTODOコメントを削除

3. **src/lib/github/__tests__/repository.test.ts** (28テスト復旧)
   - GitHubClientモックを関数ベースからクラスベースに変更
   - Octokitモックパターンも統一
   - `describe.skip()`とTODOコメントを削除

### パターン変更の詳細

#### Before (vitest v4では動作しない)
```typescript
vi.mock('@octokit/rest', () => ({
  Octokit: vi.fn().mockImplementation(() => ({ rest: {...} }))
}));
```

#### After (vitest v4で動作する)
```typescript
vi.mock('@octokit/rest', () => {
  class MockOctokit {
    rest = {...};
  }
  return { Octokit: MockOctokit };
});
```

## テスト結果

### 復旧したテスト
- 合計: **67テスト** (29 + 10 + 28)

### 全体のテスト状況
- テストファイル: **87/89 通過** (97.8%)
- テスト: **2779/2819 通過** (98.6%)
- スキップ済みテスト: 107 → 40 (**-67**)

## 品質チェック
- ✅ Linting: 通過
- ✅ Format check: 通過
- ✅ Type check: エラーなし
- ✅ Tests: 2779/2819 通過

## 関連Issue

Closes #492

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)