### PR TITLE
fix: action.yml の Node.js を v22 に更新し upload-pages-artifact を v5 へ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/configure-pages@v6
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
       

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
     
     - name: Setup environment
       shell: bash
@@ -187,7 +187,7 @@ runs:
     
     - name: Upload Pages artifact
       if: inputs.deploy-to-pages == 'true'
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: beaver-output
     


### PR DESCRIPTION
## Summary

- Dependabot PR #587 (`actions/upload-pages-artifact` v4→v5) のCI failure は **bump内容そのものとは無関係**
- 真因: `action.yml` の `setup-node` が `node-version: '20'` を指定しており、Astro 6+ が要求する `>=22.12.0` を満たしていなかった
- 本PRで Node.js を `'22'` に更新し、ついでに upload-pages-artifact も v5 にbump (#587 の意図を取り込み)

## CI failure 抜粋
```
> beaver-astro@0.1.0 build
> npx --no-install astro build

Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

## 変更ファイル

- `action.yml`: `node-version: '20'` → `'22'`、`upload-pages-artifact@v4` → `@v5`
- `.github/workflows/deploy.yml`: `upload-pages-artifact@v4` → `@v5`

## Test plan

- [ ] CI green (Test Beaver GitHub Action ジョブが Astro build を完走すること)

Closes #587

🤖 Generated with [Claude Code](https://claude.ai/code)