### PR TITLE
ci: upgrade npm to latest before npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'npm'
-          
+
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
         
@@ -77,7 +80,10 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'npm'
-          
+
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      
+
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
+
       - name: Install dependencies (include dev)
         run: |
           # Ensure devDependencies are installed (Tailwind v4 Vite plugin is a devDep)


### PR DESCRIPTION
## Summary

Dependabot PR の CI が `Missing: typescript@5.9.3 from lock file` で全件 (13件) 失敗していた問題を修正。

## Why this fails

- main の `package-lock.json` は **古い npm で生成** されており、`node_modules/astro/node_modules/typescript@5.9.3` を nested entry として含む
- Dependabot は **新しい npm (11.x) で lock を再生成** するため、`astro` が typescript 6.0.3 で互換と判断し nested entry を含まない
- git の三項マージで「PR 側が 5.9.3 を消した」と扱われ、merged lock から typescript@5.9.3 が消える
- CI 環境の npm (10.9.8) は古い resolution algorithm で「astro は typescript@5.9.3 が必要」と判定 → lock に無いので `EUSAGE` エラー

## Fix

`actions/setup-node` の直後に `npm install -g npm@latest` を挟み、CI の npm を最新化。これで Dependabot/ローカル/CI の挙動が揃い、lock の不整合が解消する。

## Files changed

- `.github/workflows/ci.yml` (2箇所: Quality Check と Run Tests)
- `.github/workflows/deploy.yml` (1箇所)

## Impact

- Node 本体や依存・lock は **無変更**
- 既存の動いている main の build/deploy も同じ workflow を通るが、`npm install -g npm@latest` は副作用がほぼなく、deploy が壊れる可能性は低い
- このマージ後、止まっていた Dependabot PR 13件に `@dependabot recreate` を投下すれば全件 CI 通過 → auto-merge される想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)