### PR TITLE
🔧 ci: Node.js を 22 → 24 (LTS) にアップグレード

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Upgrade npm to latest
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Upgrade npm to latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Upgrade npm to latest

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "vitest": "^4.1.8"
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=24.0.0"
   },
   "keywords": [
     "astro",


### PR DESCRIPTION
## 🎯 概要

CIのNode.jsバージョンを `22.x` から **24.x (LTS)** にアップグレードします。

## 🔧 変更内容

| ファイル | 変更 |
|---|---|
| `.github/workflows/ci.yml` | `node-version: 22.x → 24.x`（2箇所） |
| `.github/workflows/deploy.yml` | `node-version: 22 → 24` |
| `package.json` | `engines.node: >=22.12.0 → >=24.0.0` |

## 💡 背景

- node 22系はやや古く、現行LTSの **node 24** に揃えてビルド環境を最新化
- node 24はnpm 11系を同梱し、optional依存（プラットフォーム別バイナリ等）の解決が改善されている

## ✅ 確認事項

- [ ] CI（node 24）でlint/test/buildが通ること
- [ ] deployワークフローが正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)