### PR TITLE
🐛 fix(action): main で失敗中の "Test Beaver Action" を修正（.npmrc コピー漏れ）

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,9 @@ runs:
         cp -r "${{ github.action_path }}/src" .
         cp -r "${{ github.action_path }}/public" .
         cp "${{ github.action_path }}/package.json" .
+        # Copy .npmrc so legacy-peer-deps applies during `npm install`
+        # (eslint-plugin-jsx-a11y / eslint-plugin-react do not yet declare eslint@10 peer support)
+        cp "${{ github.action_path }}/.npmrc" .
         cp "${{ github.action_path }}/astro.config.mjs" .
         cp "${{ github.action_path }}/tailwind.config.mjs" .
         cp "${{ github.action_path }}/tsconfig.json" .


### PR DESCRIPTION
## 🎯 概要

main の **「Test Beaver Action」ワークフローが失敗** している問題を修正します。

## 🔍 根本原因

eslint 9→10 移行（#638）で eslint 10 が導入されましたが、`eslint-plugin-jsx-a11y@6.10.2`（peer: eslint `^3〜^9`）と `eslint-plugin-react@7.37.5` がまだ eslint 10 の peer サポートを宣言していません。

これに対応するため #638 はルートに `.npmrc`（`legacy-peer-deps=true`）を追加していますが、composite action（`action.yml`）の **"Create Beaver workspace" ステップが `beaver-workspace` に `.npmrc` をコピーしていなかった**ため、ワークスペース内の `npm install` で `legacy-peer-deps` が効かず **ERESOLVE** で失敗していました。

- 通常CI（Quality Check / Run Tests）は `npm ci`（lockfile使用）なので衝突を許容 → 成功
- 「Test Beaver Action」は `beaver-workspace` で `npm install`（新規解決）→ **失敗**

## 🔧 変更内容

`action.yml` のワークスペース構築時に `.npmrc` をコピーする1行を追加:

```yaml
cp "${{ github.action_path }}/package.json" .
cp "${{ github.action_path }}/.npmrc" .   # ← 追加
cp "${{ github.action_path }}/astro.config.mjs" .
```

## ✅ 確認

- [ ] 「Test Beaver Action」ワークフローが green になること

## 📌 補足

`.npmrc` のコメントにある通り、これは暫定対応です。`eslint-plugin-jsx-a11y` / `eslint-plugin-react` が eslint 10 peer サポートを公開したら `.npmrc` ごと不要になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)