### PR TITLE
🔧 fix(ci): npm 12 の EALLOWREMOTE で全 PR が赤くなる問題を解消 + dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,16 @@
 version: 2
+
+# Grouping notes
+# --------------
+# Without groups, dependabot opens one PR per dependency. Because virtually every
+# npm PR rewrites package-lock.json, only one can merge before the rest need a
+# rebase and a full CI re-run, so the queue serialises and never drains. Grouping
+# related packages into a single PR removes most of that contention.
+#
+# Groups whose members must move in lockstep (astro, eslint, typescript) are left
+# unrestricted so that major bumps land together instead of arriving as separate,
+# mutually-blocking PRs. The catch-all groups are limited to minor/patch, which
+# leaves any remaining major bump as its own PR for individual review.
 updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
@@ -9,6 +21,42 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
+    groups:
+      # astro and its integrations pin each other via peerDependencies, so a
+      # standalone bump of any one of them is not independently mergeable.
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "vite"
+          - "vite-plugin-*"
+          - "@vite-pwa/*"
+
+      # The typescript-eslint packages are published from one monorepo and share
+      # a version; splitting them produced three separate PRs for one release.
+      eslint:
+        patterns:
+          - "eslint"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "eslint-plugin-*"
+          - "eslint-config-*"
+
+      types:
+        patterns:
+          - "@types/*"
+
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -19,3 +67,7 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ env:
   GITHUB_RUN_ID: ${{ github.run_id }}
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
+  # Pinned to a major line so a breaking npm release cannot silently break CI.
+  # `npm@latest` previously did exactly that: npm 12 flipped the `allow-remote`
+  # default to `none` and every `npm ci` started failing with EALLOWREMOTE
+  # without a single change landing in this repository.
+  NPM_VERSION: '12'
 
 jobs:
   quality-check:
@@ -27,18 +32,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         
-      - name: Setup Node.js 22.x
+      - name: Setup Node.js 24.x
         uses: actions/setup-node@v6
         with:
           node-version: '24.x'
           cache: 'npm'
 
-      - name: Upgrade npm to latest
-        run: npm install -g npm@latest
+      - name: Pin npm to ${{ env.NPM_VERSION }}
+        run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Run quality checks
         run: |
           echo "🔍 Running comprehensive quality checks..."
@@ -81,12 +86,12 @@ jobs:
           node-version: '24.x'
           cache: 'npm'
 
-      - name: Upgrade npm to latest
-        run: npm install -g npm@latest
+      - name: Pin npm to ${{ env.NPM_VERSION }}
+        run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Run tests
         run: npm run test
         continue-on-error: true  # Tests may not exist yet

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,9 @@ env:
   GITHUB_RUN_ID: ${{ github.run_id }}
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
+  # Keep in sync with .github/workflows/ci.yml — see the note there on why
+  # `npm@latest` is not used.
+  NPM_VERSION: '12'
 
 jobs:
   build-and-deploy:
@@ -67,8 +70,8 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - name: Upgrade npm to latest
-        run: npm install -g npm@latest
+      - name: Pin npm to ${{ env.NPM_VERSION }}
+        run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install dependencies (include dev)
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,14 @@
 # Remove this once both plugins publish eslint 10 peer support.
 # Tracking: eslint 9 -> 10 migration (PR #636)
 legacy-peer-deps=true
+
+# npm 12 changed the `allow-remote` default from `all` to `none`, which makes
+# `npm ci` fail with EALLOWREMOTE on any dependency pinned to a tarball URL:
+#   npm error Refusing to fetch "@vite-pwa/astro@https://pkg.pr.new/@vite-pwa/astro@73"
+# package.json pins @vite-pwa/astro to a pkg.pr.new preview build because the
+# published 1.2.0 only declares peer support up to astro@5, while this project
+# is on astro@6.
+# `root` (rather than `all`) limits the exemption to URLs written in our own
+# package.json; transitive URL dependencies stay blocked.
+# Remove this once @vite-pwa/astro publishes a release supporting astro 6+.
+allow-remote=root

--- a/action.yml
+++ b/action.yml
@@ -92,8 +92,10 @@ runs:
         cp -r "${{ github.action_path }}/src" .
         cp -r "${{ github.action_path }}/public" .
         cp "${{ github.action_path }}/package.json" .
-        # Copy .npmrc so legacy-peer-deps applies during `npm install`
-        # (eslint-plugin-jsx-a11y / eslint-plugin-react do not yet declare eslint@10 peer support)
+        # Copy .npmrc so legacy-peer-deps and allow-remote apply during `npm install`
+        # (eslint-plugin-jsx-a11y / eslint-plugin-react do not yet declare eslint@10
+        # peer support; @vite-pwa/astro is pinned to a tarball URL, which npm 12
+        # refuses unless allow-remote is set)
         cp "${{ github.action_path }}/.npmrc" .
         cp "${{ github.action_path }}/astro.config.mjs" .
         cp "${{ github.action_path }}/tailwind.config.mjs" .


### PR DESCRIPTION
## 背景 — PR 滞留の調査結果

オープン PR 19 件（全件 dependabot）のうち **9 件が CI 失敗で完全にブロック**されていました。原因は PR の中身ではなく、**リポジトリ側の変更が一切ないまま `npm ci` が壊れたこと**です。

```
npm error code EALLOWREMOTE
npm error Fetching packages of type "remote" have been disabled
npm error Refusing to fetch "@vite-pwa/astro@https://pkg.pr.new/@vite-pwa/astro@73"
```

### 因果関係

- `package.json:49` が `@vite-pwa/astro` を **tarball URL** で固定している
  （公開版 1.2.0 の peer 範囲が `astro: ^1 || ... || ^5` までで、本プロジェクトの `astro@^6` を満たさないため、pkg.pr.new のプレビュービルドを暫定利用）
- **npm 12 で `allow-remote` 設定が新設され、デフォルトが `none`** に変更された
- CI は `npm install -g npm@latest` を実行していたため、npm のリリースだけで CI が破損した

破損の境界は明確です。**最後の成功は 6/29 作成の #666、7/20 の #667 以降に作成された PR は 9 件すべて同一エラー**で失敗しています。この間 `main` へのコミットはゼロです。

> 6/28〜6/29 に取得された 9 件のグリーンは、既に存在しないランナー環境での結果です。再実行すれば同じ理由で赤くなるため、実質 19/19 がブロック状態でした。

## 変更内容

### 1. `.npmrc` — URL 依存を許可（即時アンブロック）

`allow-remote=root` を追加。`all` ではなく `root` にすることで、**自プロジェクトの package.json に書かれた URL のみ**を許可し、推移的な URL 依存は引き続き遮断します。

### 2. `ci.yml` / `deploy.yml` — npm のメジャー固定（再発防止）

`npm@latest` はメジャーの破壊的変更を無警告で取り込む「時限爆弾」でした。`NPM_VERSION` 環境変数経由でメジャー固定し、3 箇所すべてを置換しています。

あわせて、実際の値とずれていたステップ名（`Setup Node.js 22.x` → `24.x`、`node-version` は `'24.x'`）を修正しました。

### 3. `action.yml` — コメントの実態合わせ

`.npmrc` を workspace に複製している理由が `legacy-peer-deps` だけでなくなったため、コメントを更新。挙動の変更はありません。

### 4. `dependabot.yml` — grouping 追加（流入量の削減）

npm PR は **19 件中 17 件が `package-lock.json` を書き換える**ため、1 件マージするたびに残り全部が rebase と CI 再実行を要求され、キューが直列化して滞留していました。実害の例:

- **#660 / #664 / #666** … `typescript-eslint`・`@typescript-eslint/eslint-plugin`・`@typescript-eslint/parser` が**すべて同じ 8.62.0 リリース**で 3 PR に分裂
- **#657（astro ^7.0.3）と #672（astro ^7.1.3）** が併存
- **#663（js-yaml 5.2.0）と #673（js-yaml 4.3.0）** が併存

astro / eslint / typescript 系のように足並みを揃える必要があるものは `update-types` を絞らず**メジャーも同一 PR に載せ**、それ以外は minor/patch のみをまとめます。残るメジャーは個別 PR として個別レビューできます。

## 検証

- ✅ npm 12.0.2 を実際に取得し、`allow-remote=none` で **CI と同一の EALLOWREMOTE を再現**、`allow-remote=root` で解消することを確認
- ✅ npm 12 の設定定義を確認（`allow-remote` は `all` / `none` / `root` の 3 値、デフォルト `none`）
- ✅ 変更した YAML 4 ファイルの構文検証
- ✅ `src/` への変更なし（quality suite の対象範囲外）

⚠️ **`npm run quality` はローカル実行できていません。** 作業環境のプロキシが `pkg.pr.new` を遮断しており（`registry.npmjs.org` は到達可能）、`npm ci` を完走できないためです。この PR の CI 実行が実質的な最初の検証になります。**CI がグリーンになること自体が、この修正が効いていることの確認**になります。

## 影響と残タスク

この PR がマージされると **9 件の PR が即座にアンブロック**されます（rebase 後）。ただし滞留の完全な解消には別途対応が必要です:

- **#659** は本 PR とは無関係の実質的なエラーです。eslint-plugin-astro 2.x の新ルールに既存コードが抵触:
  ```
  src/components/UpdateNotification.astro
    13:8  error  Exporting values from components is not allowed  astro/no-exports-from-components
  ```
- 重複 PR の整理（#657↔#672、#663↔#673）、メジャー 3 件（#661 `@astrojs/react` 6、#663 `js-yaml` 5、#672 `astro` 7）の個別判断
- 🔒 **セキュリティ更新 3 件（#657 esbuild/vite `GHSA-g7r4-m6w7-qqqr`、#672 sharp、#675 brace-expansion）が最長 42 日放置**されています。優先度は最高です

> PR のマージ・クローズ、ブランチ削除は CLAUDE.md の規約通り行っていません。上記はすべてユーザー判断です。

## 恒久対応

`@vite-pwa/astro` が astro 6+ 対応版を公開したら、pkg.pr.new 依存と `allow-remote` の両方を撤去できます（`.npmrc` にその旨を記載済み）。

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q34YaxuidWkGczpSmqnk4)_