### PR TITLE
🔧 fix(action): ワークスペースを lockfile 固定にして main の Test Beaver Action 失敗を解消

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,9 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        # Matches package.json engines (>=24.0.0) and the version CI builds with.
+        # Pinning the dependency tree only reproduces CI if the runtime matches too.
+        node-version: '24'
     
     - name: Setup environment
       shell: bash
@@ -92,10 +94,19 @@ runs:
         cp -r "${{ github.action_path }}/src" .
         cp -r "${{ github.action_path }}/public" .
         cp "${{ github.action_path }}/package.json" .
-        # Copy .npmrc so legacy-peer-deps and allow-remote apply during `npm install`
+        # Copy the lockfile so the workspace installs the exact dependency set that
+        # CI validates. Without it `npm install` re-resolved every semver range on
+        # each run, so the workspace drifted away from the tested tree and broke on
+        # unrelated upstream releases -- e.g. a @tailwindcss/vite / vite mismatch:
+        #   [@tailwindcss/vite:generate:build] Missing field `tsconfigPaths` on
+        #   BindingViteResolvePluginConfig.resolveOptions
+        cp "${{ github.action_path }}/package-lock.json" .
+        # Copy .npmrc so legacy-peer-deps and allow-remote apply during `npm ci`
         # (eslint-plugin-jsx-a11y / eslint-plugin-react do not yet declare eslint@10
         # peer support; @vite-pwa/astro is pinned to a tarball URL, which npm 12
         # refuses unless allow-remote is set)
+        # Note: npm applies legacy-peer-deps to `npm ci` as well, so the lockfile
+        # -- which was itself generated under that setting -- installs cleanly.
         cp "${{ github.action_path }}/.npmrc" .
         cp "${{ github.action_path }}/astro.config.mjs" .
         cp "${{ github.action_path }}/tailwind.config.mjs" .
@@ -141,7 +152,12 @@ runs:
       working-directory: beaver-workspace
       run: |
         echo "📦 Installing workspace dependencies..."
-        npm install
+        # `npm ci` (not `npm install`) so the lockfile is honoured exactly and a
+        # drifting transitive tree cannot break a build that CI proved green.
+        # NODE_ENV is cleared and dev dependencies forced in because consumers may
+        # run this action from a workflow with NODE_ENV=production, under which npm
+        # omits devDependencies -- and the build needs them (@tailwindcss/vite).
+        NODE_ENV= npm ci --include=dev
     
     - name: Analyze GitHub data
       id: analyze


### PR DESCRIPTION
## 背景 — main が赤い

`Test Beaver Action` ワークフローが **main で失敗**しています。#679 直後の 05:32 の実行までは成功しており、その後 dependabot 10 件をマージした 07:14 の実行から失敗に転じました。

```
[@tailwindcss/vite:generate:build] Missing field `tsconfigPaths` on
BindingViteResolvePluginConfig.resolveOptions
file: beaver-workspace/src/pages/docs/[...slug].astro?astro&type=style&index=0&lang.css
  at beaver-workspace/node_modules/@tailwindcss/vite/dist/index.mjs
```

### 原因

composite action の "Create Beaver workspace" は `package.json` をコピーする一方で **`package-lock.json` をコピーしておらず、`npm ci` ではなく `npm install`** を実行していました。

その結果、**ワークスペースだけが毎回すべての semver 範囲を再解決**します。通常 CI（Quality Check / Run Tests）は lockfile を使う `npm ci` なので緑のまま、ワークスペースだけが検証済みツリーから乖離していく——という非対称が生まれていました。今回は `@tailwindcss/vite` と `vite`/`rolldown` の解決結果がずれた瞬間に踏み抜いています。

つまりこれは**特定の依存が悪いのではなく、ワークスペースの構築方法が非再現的**だったという問題です。無関係な上流リリースが出るたびに再発しえます。

## 変更内容

### 1. `package-lock.json` をワークスペースにコピー

CI が検証したのと同一の依存ツリーを入れます。

### 2. `npm install` → `NODE_ENV= npm ci --include=dev`

- `npm ci` で lockfile を厳密に適用
- `NODE_ENV=` でクリアし `--include=dev` を明示するのは、**本 action が任意のワークフローから呼ばれる**ためです。呼び出し側が `NODE_ENV=production` を設定していると npm が devDependencies を省略し、ビルドに必要な `@tailwindcss/vite`（devDependency）が入りません。`deploy.yml` が既に採用している書き方に揃えました

### 3. `setup-node` の `node-version` を 22 → 24

`package.json` の `engines` は `>=24.0.0` で、通常 CI も 24 で検証しています。**依存ツリーだけ固定しても実行時の Node が違えば CI の再現にはならない**ため揃えました。この PR の目的（ワークスペースを CI と同じ入力で構築する）に直結するので同梱していますが、切り出しをご希望なら分離します。

これは **#655（`.npmrc` をコピーし忘れてワークスペースだけ ERESOLVE していた件）と同じ系統の不備**で、今回で「ワークスペースは通常 CI と同一の入力で構築する」形に揃います。

## 検証

- ✅ `action.yml` の YAML 構文を検証
- ✅ ワークスペース構築が npm に渡すファイル（`package.json` / `package-lock.json` / `.npmrc`）だけを別ディレクトリに再現し、npm 12.0.2 で `NODE_ENV= npm ci --include=dev --dry-run` が **lockfile 不整合エラーを出さずに解決**することを確認
- ✅ 同ディレクトリで `allow-remote=root` と `legacy-peer-deps=true` が有効になることを確認
- ✅ `package-lock.json` の root dependencies が `package.json` と一致することを確認

⚠️ **実インストールはローカルで完走できていません。** 作業環境のプロキシが `pkg.pr.new` を遮断しているためです。実ビルドの確認は **この PR の `Test Beaver Action` 実行が担います**——このジョブが緑になること自体が修正の証明になります。

## 影響

- **main の赤が解消**します
- **#691（production-dependencies グループ）も同時にアンブロック**される見込みです。#691 の `Test Beaver Action` 失敗は同じ tailwind/vite 由来で、#691 自身の変更が原因ではありません（#691 に astro は含まれず、`@astrojs/check` / sharp / react / tailwindcss のみ）

## 残る別件

この PR では扱いません。

| PR | ブロッカー |
|---|---|
| #690 | prettier フォーマット（`safe-chart.ts`, `search.ts`） |
| #687 | `astro/no-exports-from-components`（`Settings.astro:21`, `UpdateNotification.astro:13`） |
| #657 🔒 / #672 🔒 | astro 6→7 の `Tsconfig not found astro/tsconfigs/strict`（本 PR とは別の失敗） |

> PR のマージ・クローズ、ブランチ削除は CLAUDE.md の規約通り行っていません。

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q34YaxuidWkGczpSmqnk4)_