### PR TITLE
🔧 fix(components): .astro からの値 export をやめて astro/no-exports-from-components に適合

### DIFF
--- a/src/components/Settings.astro
+++ b/src/components/Settings.astro
@@ -17,8 +17,10 @@
 import { z } from 'zod';
 import { BaseUIPropsSchema } from '../lib/schemas/ui';
 
-// Settings component props schema
-export const SettingsPropsSchema = BaseUIPropsSchema.extend({
+// Settings component props schema.
+// Kept local: astro/no-exports-from-components (eslint-plugin-astro 2+) forbids
+// exporting values from a component, and nothing outside this file consumes it.
+const SettingsPropsSchema = BaseUIPropsSchema.extend({
   /** Initial open state */
   isOpen: z.boolean().default(false),
   /** Position of the settings panel */
@@ -31,7 +33,7 @@ export const SettingsPropsSchema = BaseUIPropsSchema.extend({
   title: z.string().default('設定'),
 });
 
-export type SettingsProps = z.infer<typeof SettingsPropsSchema>;
+type SettingsProps = z.infer<typeof SettingsPropsSchema>;
 
 type Props = SettingsProps;
 

--- a/src/components/UpdateNotification.astro
+++ b/src/components/UpdateNotification.astro
@@ -9,8 +9,10 @@
 import { z } from 'zod';
 import { BaseUIPropsSchema } from '../lib/schemas/ui';
 
-// UpdateNotification props schema
-export const UpdateNotificationPropsSchema = BaseUIPropsSchema.extend({
+// UpdateNotification props schema.
+// Kept local: astro/no-exports-from-components (eslint-plugin-astro 2+) forbids
+// exporting values from a component, and nothing outside this file consumes it.
+const UpdateNotificationPropsSchema = BaseUIPropsSchema.extend({
   /** Whether to show the notification */
   isVisible: z.boolean().default(false),
   /** Current version info */
@@ -31,7 +33,7 @@ export const UpdateNotificationPropsSchema = BaseUIPropsSchema.extend({
   variant: z.enum(['info', 'success', 'warning']).default('info'),
 });
 
-export type UpdateNotificationProps = z.infer<typeof UpdateNotificationPropsSchema>;
+type UpdateNotificationProps = z.infer<typeof UpdateNotificationPropsSchema>;
 
 type Props = UpdateNotificationProps;
 


### PR DESCRIPTION
## 背景

eslint-plugin-astro 2.x で追加された `astro/no-exports-from-components` に既存コードが抵触し、**#687（eslint-plugin-astro 1.7.0 → 3.1.0）の Quality Check が失敗**しています。

```
src/components/Settings.astro
  21:8  error  Exporting values from components is not allowed  astro/no-exports-from-components
src/components/UpdateNotification.astro
  13:8  error  Exporting values from components is not allowed  astro/no-exports-from-components
```

## 変更内容

両ファイルとも Props 用の Zod スキーマをコンポーネントから `export` していました。**リポジトリ全体を検索しても外部からの参照はありません**（`UpdateNotification.test.ts` はスキーマを import せず、自前で再定義しています）。スキーマはファイル内で `z.infer` による型導出と `Astro.props` の parse にしか使われていないため、`export` を外してローカルに閉じます。

型 export（`export type ...Props`）も同時にローカル化しました。こちらはルールの検出対象ではありませんが、値と型で公開範囲が食い違う状態を残す意味がないためです。

**挙動の変更はありません。**

## 検証

- ✅ 外部参照がないことを `SettingsPropsSchema` / `UpdateNotificationPropsSchema` / `SettingsProps` / `UpdateNotificationProps` の全文検索で確認
- ✅ **prettier 3.8.3（現在の main）と 3.9.6（#690 で導入予定）の両方**で、編集後の2ファイルが整形済みであることを `prettier-plugin-astro@0.14.1` 付きで確認。どちらのバージョンでも書式差分は出ません

⚠️ **eslint / astro check / vitest はローカル実行できていません。** 作業環境のプロキシが `pkg.pr.new` を遮断しており `npm ci` を完走できないためです。検証は CI が担います。

なお **この PR だけでは #687 は緑になりません。** #687 側で main を取り込む必要があります（マージ後に対応します）。

## 関連して判明した別件（本 PR では扱いません）

### 1. テストがスキーマを再定義している

`UpdateNotification.test.ts:13` はコンポーネントのスキーマを import せず同じ内容を再定義しています。単一情報源から外れており、**コンポーネント側の変更がテストに反映されません**。今回のルール適合とは別の問題なので触れていません。

### 2. #690 の prettier 問題は main には載せられない

#690（dev-dependencies グループ）が prettier を 3.8.3 → 3.9.6 に上げるため、`safe-chart.ts` と `search.ts` の union 型の折り返しで書式チェックが落ちます。実際に両バージョンで検証した結果、**2つの書式は排他**でした。

| | prettier 3.8.3 | prettier 3.9.6 |
|---|---|---|
| 現在の書式 | ✅ pass | ❌ fail |
| 3.9.6 の書式 | ❌ fail | ✅ pass |

したがって整形修正を main に載せると **main 側が壊れます**。prettier のアップグレードと同一コミットで入れる必要があり、本 PR には含めていません。

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q34YaxuidWkGczpSmqnk4)_