### PR TITLE
🔧 fix(format): union 型の書式を prettier のバージョンに依存させない

### DIFF
--- a/src/components/charts/types/safe-chart.ts
+++ b/src/components/charts/types/safe-chart.ts
@@ -242,6 +242,10 @@ export interface TimeSeriesPoint {
 /**
  * Result type for error handling
  */
+// prettier-ignore -- keep the discriminated union one variant per line. prettier 3.9
+// collapses it onto a single line because it fits in printWidth, which reformats the
+// file purely on the prettier version in use; pinning the layout keeps the shape the
+// project documents for Result types and decouples it from formatter churn.
 export type SafeChartResult<T, E = Error> =
   | { success: true; data: T }
   | { success: false; error: E };

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -341,6 +341,8 @@ export async function searchIssuesWithClassification(
 ): Promise<SearchResult> {
   try {
     // If priority sorting is requested, compute classification data
+    // prettier-ignore -- see safe-chart.ts: prettier 3.9 collapses this union onto one
+    // line, so the layout would depend on the formatter version rather than on us.
     let classificationData:
       | Record<number, { priority: 'critical' | 'high' | 'medium' | 'low' | 'backlog' }>
       | undefined;


### PR DESCRIPTION
## 背景

**#690（dev-dependencies グループ 12件）が prettier を 3.8.3 → 3.9.6 に上げる**と、書式チェックが2ファイルで失敗します。

```
[warn] src/components/charts/types/safe-chart.ts
[warn] src/lib/utils/search.ts
[warn] Code style issues found in 2 files. Run Prettier with --write to fix.
```

prettier 3.9 は printWidth に収まる union 型を1行に畳むよう挙動が変わりました。**両バージョンを実際に取得して整形・比較したところ、2つの書式は排他**でした。

| | prettier 3.8.3（現 main） | prettier 3.9.6（#690） |
|---|---|---|
| 現在の書式 | ✅ pass | ❌ fail |
| 3.9.6 の整形結果 | ❌ fail | ✅ pass |

つまり **3.9.6 の整形結果をそのまま main に入れると main 側が壊れ、放置すると #690 が通りません。**

## 採った方針と、採らなかった方針

### 採らなかった案: 3.9.6 の整形結果を採用する

prettier の更新と同一コミットに載せるしかなく、実質 **dependabot のブランチに直接 push** することになります。そのブランチは以後 dependabot の管理から外れるという副作用があります。

### 採った案: `prettier-ignore` で書式を固定する

該当2箇所に `prettier-ignore` を置き、判別可能 union を「1行1バリアント」のまま固定します。

- **両バージョンで書式チェックが通る**ため、この修正を main 単独で入れられる
- **dependabot のブランチに触れずに #690 をアンブロックできる**
- Result 型についてプロジェクトが文書化している形（CLAUDE.md）を維持できる
- 以後 prettier のバージョン差で同じ箇所が揺れなくなる

**型そのものの変更はありません。**

## 検証

- ✅ prettier 3.8.3 と 3.9.6（#690 の lockfile が固定するものと同一）を実際に取得し、リポジトリの `.prettierrc.json` 相当の設定で `--check` が**両方 pass** することを確認
- ✅ `prettier-ignore` 未適用では 3.9.6 が **fail** することも確認済みで、抑止が実際に効いていることを裏付けています（コメント行を挟んでも有効）
- ✅ `prettier --write` を CI と同一の glob（`src/**/*.{js,jsx,ts,tsx,astro,json,md}`）で流し、影響を受けるのがこの2ファイルのみであることを確認

⚠️ 作業環境のプロキシが `pkg.pr.new` を遮断しており `npm ci` を完走できないため、eslint / astro check / vitest はローカル実行できていません。ただし本 PR の変更はコメント追加のみで、実行時の挙動には影響しません。

## この PR だけでは #690 は緑になりません

マージ後、**#690 側で main を取り込む必要があります**（対応します）。

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q34YaxuidWkGczpSmqnk4)_