### PR TITLE
🐛 fix(format): prettier-ignore が効いていなかったのを修正（#694 の不具合）

### DIFF
--- a/src/components/charts/types/safe-chart.ts
+++ b/src/components/charts/types/safe-chart.ts
@@ -242,10 +242,13 @@ export interface TimeSeriesPoint {
 /**
  * Result type for error handling
  */
-// prettier-ignore -- keep the discriminated union one variant per line. prettier 3.9
-// collapses it onto a single line because it fits in printWidth, which reformats the
-// file purely on the prettier version in use; pinning the layout keeps the shape the
-// project documents for Result types and decouples it from formatter churn.
+// Keep the discriminated union at one variant per line. prettier 3.9 collapses it onto
+// a single line because it fits in printWidth, which would make the layout depend on the
+// formatter version rather than on us; pinning it keeps the shape the project documents
+// for Result types.
+// The directive below must stay on its own line with no trailing text -- prettier only
+// honours a comment whose entire body is `prettier-ignore`.
+// prettier-ignore
 export type SafeChartResult<T, E = Error> =
   | { success: true; data: T }
   | { success: false; error: E };

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -341,8 +341,10 @@ export async function searchIssuesWithClassification(
 ): Promise<SearchResult> {
   try {
     // If priority sorting is requested, compute classification data
-    // prettier-ignore -- see safe-chart.ts: prettier 3.9 collapses this union onto one
-    // line, so the layout would depend on the formatter version rather than on us.
+    // See safe-chart.ts: prettier 3.9 collapses this union onto one line, so the layout
+    // would depend on the formatter version rather than on us. The directive must stay
+    // on its own line with no trailing text.
+    // prettier-ignore
     let classificationData:
       | Record<number, { priority: 'critical' | 'high' | 'medium' | 'low' | 'backlog' }>
       | undefined;


### PR DESCRIPTION
## これは #694 の不具合修正です

**#694 で追加した `prettier-ignore` は機能していませんでした。** そのため #690（prettier 3.8.3 → 3.9.6）の Quality Check は #694 マージ後も同じ2ファイルで失敗したままです。

```
[warn] src/components/charts/types/safe-chart.ts
[warn] src/lib/utils/search.ts
```

### 原因

prettier は**コメント本体が丸ごと `prettier-ignore` である場合しか**ディレクティブとして認識しません。#694 では

```ts
// prettier-ignore -- keep the discriminated union one variant per line. prettier 3.9
```

のように同じ行へ説明を続けていたため、**ただのコメントとして無視**されていました。

### 修正

説明を直前の行へ移し、ディレクティブを単独行にします。取り違えやすい箇所なので、末尾にテキストを足すと無効になる旨もコメントに残しました。

```ts
// Keep the discriminated union at one variant per line. ...
// The directive below must stay on its own line with no trailing text -- prettier only
// honours a comment whose entire body is `prettier-ignore`.
// prettier-ignore
export type SafeChartResult<T, E = Error> =
  | { success: true; data: T }
  | { success: false; error: E };
```

**型そのものの変更はありません。**

## #694 の検証がなぜ誤っていたか

これも記録しておきます。#694 では**スクラッチパッドへ複製したファイル**を `--config` 付きで検査して pass を確認していました。しかしその配置では prettier がプロジェクトの設定を解決できず（`resolveConfig` が `null`）、**CI とは別の条件を測っていた**ことになります。同じ内容でもリポジトリ内の実パスに置くと FAIL しました。

今回はリポジトリ内の実ファイルに対し、CI と同一の条件で検証しています。

## 検証

- ✅ prettier **3.8.3 と 3.9.6 の両方**で、リポジトリ内の実パス・実設定（`.prettierrc.json` + `prettier-plugin-astro`）のもと、**CI と同一の glob** `--check "src/**/*.{js,jsx,ts,tsx,astro,json,md}"` が `All matched files use Prettier code style!` になることを確認
- ✅ ディレクティブの形を4通り用意して実パスで比較し、原因を特定

| 形 | prettier 3.8.3 | prettier 3.9.6 |
|---|---|---|
| 末尾にテキストあり（#694 の形） | ✅ pass | ❌ **fail** |
| 単独行 `// prettier-ignore` | ✅ pass | ✅ pass |
| 説明を前行に置いて単独行（本 PR） | ✅ pass | ✅ pass |
| ディレクティブなし | ✅ pass | ❌ fail |

## この PR だけでは #690 は緑になりません

マージ後、**#690 側で main を取り込む必要があります**（対応します）。

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q34YaxuidWkGczpSmqnk4)_