### PR TITLE
🧪 test: CI を断続的に赤くしていた 2 つの flaky テストを修正（#610 を含む）

### DIFF
--- a/src/components/docs/__tests__/DocsSearch.test.tsx
+++ b/src/components/docs/__tests__/DocsSearch.test.tsx
@@ -238,12 +238,16 @@ describe('DocsSearch Component', () => {
         expect(screen.getByText('Result 1')).toBeInTheDocument();
       });
 
-      // Arrow down to select first result
-      fireEvent.keyDown(document, { key: 'ArrowDown' });
+      // Arrow down to select first result.
+      // user.keyboard (not fireEvent) so the interaction is wrapped in act and the
+      // component's keydown listener -- which is re-registered by an effect on every
+      // isOpen/results/selectedIndex change -- is guaranteed to be the current one.
+      await user.keyboard('{ArrowDown}');
 
       // First result should be selected
-      const firstButton = screen.getByText('Result 1').closest('button');
-      expect(firstButton).toHaveClass('bg-blue-50');
+      await waitFor(() => {
+        expect(screen.getByText('Result 1').closest('button')).toHaveClass('bg-blue-50');
+      });
     });
 
     it('should cycle through results with arrow keys', async () => {
@@ -257,11 +261,11 @@ describe('DocsSearch Component', () => {
       });
 
       // Arrow down twice to select second result
-      fireEvent.keyDown(document, { key: 'ArrowDown' });
-      fireEvent.keyDown(document, { key: 'ArrowDown' });
+      await user.keyboard('{ArrowDown}{ArrowDown}');
 
-      const secondButton = screen.getByText('Result 2').closest('button');
-      expect(secondButton).toHaveClass('bg-blue-50');
+      await waitFor(() => {
+        expect(screen.getByText('Result 2').closest('button')).toHaveClass('bg-blue-50');
+      });
     });
 
     it('should navigate to selected result with Enter key', async () => {
@@ -282,10 +286,11 @@ describe('DocsSearch Component', () => {
       });
 
       // Select first result and press Enter
-      fireEvent.keyDown(document, { key: 'ArrowDown' });
-      fireEvent.keyDown(document, { key: 'Enter' });
+      await user.keyboard('{ArrowDown}{Enter}');
 
-      expect(mockLocation.href).toBe('/docs/result1');
+      await waitFor(() => {
+        expect(mockLocation.href).toBe('/docs/result1');
+      });
     });
 
     it('should close results with Escape key', async () => {
@@ -298,9 +303,11 @@ describe('DocsSearch Component', () => {
         expect(screen.getByText('Result 1')).toBeInTheDocument();
       });
 
-      fireEvent.keyDown(document, { key: 'Escape' });
+      await user.keyboard('{Escape}');
 
-      expect(screen.queryByText('Result 1')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('Result 1')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/src/lib/services/__tests__/TaskRecommendationService.test.ts
+++ b/src/lib/services/__tests__/TaskRecommendationService.test.ts
@@ -14,19 +14,6 @@ import {
 import type { Issue } from '../../schemas/github';
 import type { TaskScore, EnhancedTaskScore } from '../../types/enhanced-classification';
 
-// Mock enhanced classification dependencies
-vi.mock('../../classification/enhanced-config-manager', () => ({
-  enhancedConfigManager: {
-    getConfig: vi.fn(() =>
-      Promise.resolve({
-        version: '2.0.0',
-        algorithm: 'enhanced-v2',
-        thresholds: { minConfidence: 0.5 },
-      })
-    ),
-  },
-}));
-
 // Mock for Enhanced Classification Engine
 const mockClassifyIssuesBatch = vi.fn();
 
@@ -42,6 +29,12 @@ vi.mock('../../classification/engine', () => ({
   })),
 }));
 
+// Keep this the ONLY vi.mock for enhanced-config-manager in this file. A second
+// factory used to sit above and expose just getConfig, with no loadConfig. vitest
+// resolves same-action mocks in parallel and registers them last-write-wins, so
+// whichever resolved last won -- and when the loadConfig-less one did, every call
+// site below blew up with `enhancedConfigManager.loadConfig is not a function`,
+// which the service swallowed into a fallback that scores every issue 52.
 vi.mock('../../classification/enhanced-config-manager', () => ({
   enhancedConfigManager: {
     getConfig: vi.fn(() =>


### PR DESCRIPTION
## 背景

無関係な PR を巻き込んで CI を赤くしていた flaky テストが2件あります。**どちらもテスト側の問題で、製品コードの不具合ではありません。**

### flaky であることの客観的証拠

| 証拠 | 内容 |
|---|---|
| 同一コミットでの結果割れ | #690 `c23d6ff` の同一 run で **attempt1=failure / attempt2=success**（コード差分ゼロ） |
| 同上 | #696 `a6eeec4` の同一 run で attempt1 はテスト4件失敗、**attempt2 はテスト通過** |
| 発生頻度 | `DocsSearch` **61回中3回（4.9%）**、`TaskRecommendationService` **61回中1回**。分母は vitest が実際に走った run 数（npm ci 失敗や lint/format で手前で止まった赤は除外） |
| 新規性なし | `DocsSearch:264` は **2026-06-28 の main でも失敗**（run 28313052470）。今回の依存更新とは無関係の既存問題 |

## 1. `DocsSearch.test.tsx`（Issue #610 を含む）

キーボード操作の4テストが `fireEvent.keyDown(document, ...)` の直後に **await を挟まず同期で** assert していました。

`DocsSearch` のキーボードリスナは `document` へ直接登録され、依存配列が `[isOpen, results, selectedIndex, navigateToResult]` なので **state が変わるたびに貼り直されます**（`DocsSearch.tsx:88-118`）。`waitFor` が保証するのは DOM にテキストが出たことだけで、**この再登録（passive effect）の完了は保証しません**。

未フラッシュのまま keydown を撃つと、マウント時の `isOpen=false` クロージャが処理して `if (!isOpen) return;` で握り潰され、`selectedIndex` が `-1` のまま残ります。

### これで観測事実がすべて説明できます

| 事象 | 説明 |
|---|---|
| 264行目 選択クラスが付かない | ArrowDown が無視され `selectedIndex = -1` |
| 288行目 `href` が空 | 同上で Enter が no-op |
| 303行目 Escape が効かない（#610） | 同じ古いリスナが `!isOpen` で return |
| **単独実行では通り、フルスイートでのみ落ちる** | 負荷が高いと commit 後に yield し、effect が後回しになる |
| **落ちる行が回ごとに変わる** | どの commit が予算超過するかがランタイム依存 |
| **マウス操作系だけ落ちない** | 依存配列が `[]` でマウント時登録、かつ `await user.click()` |

最後の非対称性が決定的な裏づけです。

| effect | 依存配列 | 登録タイミング |
|---|---|---|
| `keydown`（落ちる） | `[isOpen, results, selectedIndex, navigateToResult]` | state 変化のたび貼り直し |
| `mousedown`（落ちない） | `[]` | マウント時＝`render()` の `act()` 内 |

### 修正

`fireEvent` + 同期 assert を `await user.keyboard(...)` + `waitFor` に置き換えます。user-event は `asyncWrapper` 経由で `act` に包まれるため、リスナ再登録が完了してからイベントが飛びます。

## 2. `TaskRecommendationService.test.ts`

同一モジュールに対する `vi.mock` が**2つ**あり、先頭のファクトリには `loadConfig` がありませんでした。vitest は同種の mock を並列解決し**後勝ち**で登録するため、`loadConfig` の無い方が勝った実行では3件が揃って落ちます。

```
loadConfig is not a function (service:545)
  → getPriorityScore / getCategoryScore が例外
  → catch のフォールバックが priority/category を無視 (service:659)
  → 全 issue が 50 + ラベル2 = 52 に潰れる
  → expected 52 to be greater than 52 が 2 件
```

正常時は High=89 / Medium=69 で余裕を持って通ります。**数値が完全一致するのが裏づけ**です。

### 修正

先頭のファクトリを削除して1つに統一します。残す方は `getConfig` と `loadConfig` の両方を持つ上位互換で、削除する側にしかない機能はありません。なお **`getConfig` は実装側から一度も呼ばれていません**（呼ばれるのは `loadConfig` のみ）。再発防止として理由をコメントに残しました。

## 検証

- ✅ CI と同一の glob で prettier **3.8.3 と 3.9.6 の両方**が pass することを確認
- ✅ `fireEvent` は 369 行目のマウス系で引き続き使われており import は有効
- ✅ `enhancedConfigManager` の mock 箇所をリポジトリ全体で検索し、重複がこの1ファイルのみだったことを確認
- ✅ `getConfig` が実装側から呼ばれていないことを検索で確認

⚠️ **vitest をローカル実行できていません。** 作業環境のプロキシが `pkg.pr.new` を遮断しており `npm ci` を完走できないためです。実際の安定性確認は CI が担います。flaky の性質上、1回の green は「直った」ことの証明にはなりません。**マージ後に数回 CI が回るのを見て確認するのが確実**です。

## この PR では扱わない、調査中に見つかった別件

| 項目 | 内容 |
|---|---|
| **`ci.yml` の `Run Tests` が無意味** | `continue-on-error: true` が付いており、テストが落ちても success になる。実際の合否は `Quality Check` の `4/4 Testing` だけが握っている |
| **act 警告が握り潰されている** | `DocsSearch.test.tsx:22-24` と `src/test/setup.ts` の両方で `console.error` がモックされ、`not wrapped in act(...)` が消えている。同種のバグが再発しても気づけない |
| **`DocsSearch.tsx` の設計** | keydown を `document` ではなく `<input>` の `onKeyDown` へ移すと本質的に安定する。検索レスポンスの競合ガード（AbortController）も無く、入力中に古い応答が新しい結果を上書きしうる |
| **`window.location` の差し替えが復元されない** | `configurable: true` も未指定で脆い |
| **#696 の実ブロッカー** | astro 7 / vite 8 が esbuild を同梱しなくなり、`transformWithEsbuild` がビルド時に失敗する。これは flaky ではなく本物 |

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q34YaxuidWkGczpSmqnk4)_