### PR TITLE
🔧 fix(build): minify をバージョン非依存にして astro 7 / vite 8 のビルド失敗を解消

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -252,7 +252,14 @@ export default defineConfig({
     build: {
       // Performance optimizations
       target: 'es2020',
-      minify: 'esbuild',
+      // `true` rather than 'esbuild' so the minifier tracks whatever vite ships with.
+      // vite normalises true to 'esbuild' on v7 (which depends on esbuild) and to 'oxc'
+      // on v8, where esbuild became an *optional peer* dependency and is no longer
+      // installed -- pinning 'esbuild' there fails the build with
+      //   Failed to load `transformWithEsbuild`. It is deprecated and it now requires
+      //   esbuild to be installed separately.
+      // because vite's buildEsbuildPlugin is only registered for minify === 'esbuild'.
+      minify: true,
       rollupOptions: {
         external: ['jsdom'],
       },


### PR DESCRIPTION
## 背景

**#696（astro 6.4.6 → 7.1.1）のビルドが失敗します。** これは flaky ではなく再現性のある実ブロッカーで、同一コミットの再実行でも同じ場所で落ちることを確認済みです。

```
Failed to load `transformWithEsbuild`. It is deprecated and it now requires
esbuild to be installed separately.
Caused by: Cannot find package 'esbuild' imported from
  node_modules/vite/dist/node/chunks/node.js
```

## 原因

astro 7 は vite 8 を要求し、**vite 8 は esbuild を `dependencies` から optional な `peerDependencies`（`^0.27.0 || ^0.28.0`）へ降格**しました。このため lockfile から root の `node_modules/esbuild` が消え、`node_modules/vite` からは解決できなくなります。

| | astro | vite | root の esbuild |
|---|---|---|---|
| main | 6.4.6 | 7.3.2 | ✅ 0.27.7 |
| #696 | 7.1.1 | 8.2.1 | ❌ なし（`astro/` と `tsx/` の下にネストのみ） |

そして **vite が esbuild を要求するのは `build.minify === 'esbuild'` の経路だけ**で、`astro.config.mjs` がそれを明示指定していました。

```js
// vite 8.2.1 node.js:33571
...isBuild && config.build.minify === "esbuild" ? [buildEsbuildPlugin()] : [],
// node.js:3464 — buildEsbuildPlugin の renderChunk が transformWithEsbuild を呼ぶ
```

## 修正

`'esbuild'` 固定をやめて `true` にします。**vite は `true` を自分のバージョンに応じて正規化する**ため、どちらでも成立します。

| vite | 正規化 | esbuild |
|---|---|---|
| 7（現 main） | `config.js:33396` `true` → `"esbuild"` | 同梱済み ✅ |
| 8（#696） | `node.js:33544` `true` → `"oxc"` | 不要 ✅ |

つまり **現在の main では挙動が完全に同一**（`'esbuild'` に正規化される）で、astro 7 が入った時点で oxc に切り替わります。#697 の prettier 対応と同じく、**main 単独で先に入れられる**形です。

`cssMinify` も確認しましたが、既定が `!!minify`（真偽値）で `"esbuild"` 文字列とは一致しないため、この経路で esbuild が要求されることはありません（`node.js:33549`）。vite 8 が esbuild を動的 import する箇所は `transformWithEsbuild` と `cssMinify === 'esbuild'` の2つだけで、いずれも該当しなくなります。

## 検証 — 実際にビルドして対照実験しました

**astro 7.1.1 / vite 8.2.1 / root esbuild なし**の環境を再現し、`minify` の値だけを変えて比較：

| `minify` | 結果 |
|---|---|
| `'esbuild'`（修正前） | ❌ `Failed to load \`transformWithEsbuild\`` — **CI と同一のエラー** |
| `true`（本 PR） | ✅ **`33 page(s) built` / `Complete!`** |

**astro 6.4.6 / vite 7.3.2（現在の main と同じ構成）**でも：

| `minify` | 結果 |
|---|---|
| `true`（本 PR） | ✅ `33 page(s) built` / `Complete!` |

⚠️ 検証環境では プロキシが `pkg.pr.new` を遮断しているため、`@vite-pwa/astro` のみ除外してインストールしています。`minify` の経路には影響しませんが、**完全な同一条件ではない**点は CI での確認が必要です。

## この PR だけでは #696 は緑になりません

マージ後、**#696 側で main を取り込む必要があります**（対応します）。

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q34YaxuidWkGczpSmqnk4)_